### PR TITLE
Allow constructor name to be overridden in subclasses.

### DIFF
--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -537,14 +537,21 @@ var createDerivedProperty = function (modelProto, name, definition) {
     });
 };
 
-var extend = function (spec) {
+var extend = function (/*[newConstructorName],*/spec) {
     var parent = this;
     var BaseClass = this._super || Base;
     var props, session, derived, collections;
+    var constructorName = this._constructorName || 'State';
 
-    function State() {
-        BaseClass.apply(this, arguments);
+    var args = Array.prototype.slice.call(arguments);
+
+    //Override constructor name if passed
+    if (typeof args[0] === 'string' && (typeof args[1] === 'object' || typeof args[1] === 'undefined')) {
+        constructorName = args[0];
+        spec = args[1] || {};
     }
+
+    var State = eval("(function " + constructorName + "() { BaseClass.apply(this, arguments); })");
 
     // Add our special accessor properties
     Object.defineProperties(State.prototype, accessors);
@@ -607,6 +614,7 @@ var extend = function (spec) {
 
     // Keep reference to super human™
     State._super = State;
+    State._constructorName = constructorName;
 
     // Maintain ability to further extend
     State.extend = extend;

--- a/test/main.js
+++ b/test/main.js
@@ -50,6 +50,33 @@ test('extended object maintains existing methods', function (t) {
     t.end();
 });
 
+test('extended object can have a custom constructor name', function (t) {
+    //Default constructor is 'State'
+    var BaseState = State.extend({});
+    var baseItem = new BaseState();
+    t.ok(baseItem.constructor.toString().match(/function State/));
+
+    //Can override constructor name on extend
+    var Model = BaseState.extend('Model', { model: true });
+    var model = new Model();
+    t.ok(model.model);
+    t.ok(model.constructor.toString().match(/function Model/));
+
+    //Will maintain overridden down the chain
+    var Dog = Model.extend({ dog: true });
+    var dog = new Dog();
+    t.ok(dog.dog);
+    t.ok(dog.constructor.toString().match(/function Model/));
+
+    //Or you can override again
+    var MyDog = Dog.extend('MyDog', { myDog: true });
+    var myDog = new MyDog();
+    t.ok(myDog.myDog);
+    t.ok(myDog.constructor.toString().match(/function MyDog/));
+
+    t.end();
+});
+
 test('cached derived properties are calculated once per change', function (t) {
     var count = 0;
     var NewPerson = Person.extend({


### PR DESCRIPTION
So I appreciate that the implementation is, ahem, somewhat dubious. However, this does solve a pretty annoying thing.

It's always been pretty annoying to me that logging a model in development gives you a constructor name or 'child' or 'Model', rather than something useful. This is now even more confusing with ampersand state being the base constructor as logging an ampersand-model gives you a constructor like `State {cid: 'model4', ... }` which kinda couldn't be more generic.

This change (or something similar) would allow ampersand-model to rename the constructor something closer to what it is (at the very least Model or AmpersandModel), and optionally allow developers to rename stuff further down the chain too. e.g:

![b e e f y 2014-03-23 16-02-18](https://f.cloud.github.com/assets/78225/2493723/8370f430-b2a4-11e3-804c-44bbbac89aa5.png)
