### PR TITLE
Fix some missing uses of _.isEqual without checking if custom compare is set first.

### DIFF
--- a/test/full.js
+++ b/test/full.js
@@ -524,6 +524,42 @@ test('Should be able to define and use custom data types', function (t) {
     t.end();
 });
 
+test('Uses dataType compare', function (t) {
+    var compareRun;
+
+    var Foo = State.extend({
+        props: {
+            silliness: 'crazyType'
+        },
+        dataTypes: {
+            crazyType: {
+                compare: function (oldVal, newVal) {
+                    compareRun = true;
+                    return false;
+                },
+                set: function (newVal) {
+                    return {
+                        val: newVal,
+                        type: 'crazyType'
+                    };
+                },
+                get: function (val) {
+                    return val + 'crazy!';
+                }
+            }
+        }
+    });
+
+    compareRun = false;
+    var foo = new Foo({ silliness: 'you' });
+    t.assert(compareRun);
+
+    compareRun = false;
+    foo.silliness = 'they';
+    t.assert(compareRun);
+    t.end();
+});
+
 test('Should only allow nulls where specified', function (t) {
     var foo = new Foo({
         firstName: 'bob',


### PR DESCRIPTION
Looks like the issue you had was caused by not using the compare function. Spotted a potential issue in `changedAttributes` too.

I also spotted what I _thought_ was also an issue, with the use of _.isEqual for checking derived properties, but I see now that derivedProperties aren't allowed to be custom types, so we can only use _.isEqual for them. Is that something that should change too?

Please check my assumptions on how set works are correct, it's a pretty complex fn that I don't fully comprehend yet.
