### PR TITLE
'change' events should bubble up from children too

### DIFF
--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -405,6 +405,8 @@ _.extend(Base.prototype, BBEvents, {
         return _.bind(function (name, model, newValue) {
             if (changeRE.test(name)) {
                 this.trigger('change:' + propertyName + '.' + name.split(':')[1], model, newValue);
+            } else if (name === 'change') {
+                this.trigger('change', this);
             }
         }, this);
     },

--- a/test/full.js
+++ b/test/full.js
@@ -954,6 +954,8 @@ test('listens to child events', function (t) {
         }
     });
 
+    t.plan(7);
+
     //Change property
     first.once('change:name', function (model, newVal) {
         t.equal(newVal, 'new-first-name');
@@ -971,13 +973,17 @@ test('listens to child events', function (t) {
 
 
     //Change grand child property
-    first.on('change:firstChild.grandChild.name', function (unsure, name) {
+    first.once('change:firstChild.grandChild.name', function (unsure, name) {
         t.equal(name, "Phil");
     });
     first.firstChild.grandChild.name = 'Phil';
     t.equal(first.firstChild.grandChild.name, 'Phil');
 
-    t.end();
+    //Propagates change events from children too
+    first.once('change', function (model) {
+        t.equal(model, first);
+    });
+    first.firstChild.grandChild.name = 'Bob';
 });
 
 test('Should be able to declare derived properties that have nested deps', function (t) {


### PR DESCRIPTION
This is needed by ampersand-view for waitFor in subviews at lease.
