### PR TITLE
Document incompatibility with Coffeescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ var Person = AmpersandState.extend({
 });
 ```
 
+`AmpersandState.extend` does more than just copy attributes from one prototype to another.  It also sets up several new objects on the newly created prototype.  This renders it incompatible with Coffeescript's class based extend.
+
+For instance, this will not work since it never calls `AmpersandState.extend`:
+
+    class Foo extends AmpersandView
+         constructor: (options)->
+             @special = options.special
+             super
+
+
+
 ### constructor/initialize `new AmpersandState([attrs], [options])`
 
 When creating an instance of a state object, you can pass in the initial values of the **attributes** which will be [set](#ampersand-state-set) on the model. Unless [extraProperties](#amperand-state-extra-properties) is set to `allow`, you will need to have defined these attributes in `props` or `session`.


### PR DESCRIPTION
I'm not sure it should be mentioned so prominently, so feel free to reject and point me in a better location.

Coffeescript has a built-in `extend` method that is compatible with Backbone's extend.  Because of that, you can write Coffeescript "Classes" that inherit from Backbone Views/Models/Collections.  i.e.

```
class Foo extends Backbone.View
     constructor: (options)->
         super

    render: ->
        view stuff
        super
```

And it all "just works".  About the only advantage of writing code in this fashion is the handy use of "super" to call the overwritten method.

Writing code in this fashion with Ampersand Views breaks in non-obious ways. No exceptions are thrown, things just don't work correctly.

What happens is that Coffeescript will call it's built-in extend method, which copies all the functions onto the prototype, and records the parent information for super, but that's about it.  It never calls AmpersandState.extend, so none of the special prototype objects are created, leading to strange behavior later.  I noticed it when I couldn't get subviews to render at all.

For my purposes, this isn't a deal-breaker.  I've always been ambivalent about the Coffeescript's class usage with Backbone, so will be fine going back to the explicit extend pattern.  For others, it probably will be since it's hard to let `super` go.
