### PR TITLE
Allow `null` to be provided as the default value

### DIFF
--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -513,7 +513,7 @@ function createPropertyDefinition(object, name, desc, isSession) {
 
         if (desc.required) def.required = true;
 
-        if (typeof desc.default === 'object') {
+        if (desc.default && typeof desc.default === 'object') {
             throw new TypeError('The default value for ' + name + ' cannot be an object/array, must be a value or a function which returns a value/object/array');
         }
         def.default = desc.default;

--- a/test/full.js
+++ b/test/full.js
@@ -35,6 +35,7 @@ function reset() {
             list: ['array'],
             myBool: ['boolean', true, false],
             someNumber: {type: 'number', allowNull: true},
+            someNull: {type: 'object', default: null},
             good: {
                 type: 'string',
                 test: function (newVal) {
@@ -98,6 +99,7 @@ test('should have default values for properties', function (t) {
         lastName: 'tom'
     });
     t.strictEqual(foo.myBool, false);
+    t.strictEqual(foo.someNull, null);
     t.end();
 });
 
@@ -305,13 +307,15 @@ test('should have data serialization methods', function (t) {
         lastName: 'tom',
         thing: 'abc',
         myBool: false,
-        active: true
+        active: true,
+        someNull: null
     });
     t.deepEqual(foo.serialize(), {
         firstName: 'bob',
         lastName: 'tom',
         thing: 'abc',
-        myBool: false
+        myBool: false,
+        someNull: null
     });
     t.end();
 });


### PR DESCRIPTION
This allows the default value to be set to `null`. Without this change it fails because `typeof null === 'object'`, and objects are not allowed as the default value. I also updated the tests to test this behavior.
