### PR TITLE
Allow extending with 'class' or static properties

### DIFF
--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -673,7 +673,7 @@ var dataTypes = {
 
 // the extend method used to extend prototypes, maintain inheritance chains for instanceof
 // and allow for additions to the model definitions.
-function extend(protoProps) {
+function extend(protoProps,staticProps) {
     var parent = this;
     var child;
     var args = [].slice.call(arguments);
@@ -691,7 +691,7 @@ function extend(protoProps) {
     }
 
     // Add static properties to the constructor function from parent
-    _.extend(child, parent);
+    _.extend(child, parent, staticProps);
 
     // Set the prototype chain to inherit from `parent`, without calling
     // `parent`'s constructor function.


### PR DESCRIPTION
Not sure if this was omitted on purpose, here's a link to where backbone does this:

https://github.com/jashkenas/backbone/blob/master/backbone.js#L1643
