### PR TITLE
dont override cid

### DIFF
--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -6,7 +6,7 @@ var changeRE = /^change:/;
 
 function Base(attrs, options) {
     options || (options = {});
-    this.cid = _.uniqueId('state');
+    this.cid || (this.cid = _.uniqueId('state'));
     this._events = {};
     this._values = {};
     this._definition = Object.create(this._definition);

--- a/package.json
+++ b/package.json
@@ -15,9 +15,13 @@
   "devDependencies": {
     "ampersand-collection": "^1.3.2",
     "ampersand-registry": "0.x.x",
-    "precommit-hook": "~0.3.10",
+    "browserify": "^5.9.1",
+    "jshint": "^2.5.3",
+    "precommit-hook": "^1.0.7",
     "run-browser": "~1.2.0",
-    "tape": "~2.12.1"
+    "tap-spec": "^0.2.0",
+    "tape": "~2.12.1",
+    "tape-run": "^0.2.0"
   },
   "homepage": "https://github.com/ampersandjs/ampersand-state",
   "keywords": [
@@ -32,7 +36,7 @@
     "url": "git://github.com/ampersandjs/ampersand-state"
   },
   "scripts": {
-    "test": "node test/index.js",
+    "test": "browserify test/index.js | tape-run | tap-spec",
     "validate": "jshint .",
     "start": "run-browser test/index.js"
   },


### PR DESCRIPTION
The `cid` was bugging me because things that extend `ampersand-state` (like `ampersand-view`) were always having their `cid` set to `stateN` instead of `viewN`. Is it safe to assume that if an instance already has a cid property that it should not be overwritten?

Also a few other cleanup changes:
- update precommit-hook
- use browserify, tape-run and tap-spec to run tests
