### PR TITLE
Refactoring: remove unused variables and update tests.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -8,5 +8,6 @@
     "undef": true,
     "node": true,
     "indent": 4,
-    "eqnull": true
+    "eqnull": true,
+    "unused": true
 }

--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -75,7 +75,7 @@ _.extend(Base.prototype, BBEvents, {
 
     // Parse can be used remap/restructure/rename incoming properties
     // before they are applied to attributes.
-    parse: function (resp) {
+    parse: function (resp, options) {
         return resp;
     },
 

--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -75,7 +75,7 @@ _.extend(Base.prototype, BBEvents, {
 
     // Parse can be used remap/restructure/rename incoming properties
     // before they are applied to attributes.
-    parse: function (resp, options) {
+    parse: function (resp) {
         return resp;
     },
 
@@ -98,7 +98,6 @@ _.extend(Base.prototype, BBEvents, {
     set: function (key, value, options) {
         var self = this;
         var extraProperties = this.extraProperties;
-        var triggers = [];
         var changing, changes, newType, newVal, def, cast, err, attr,
             attrs, dataType, silent, unset, currentVal, initial, hasChanged, isEqual;
 
@@ -295,7 +294,6 @@ _.extend(Base.prototype, BBEvents, {
 
     unset: function (attr, options) {
         var def = this._definition[attr];
-        var type = def.type;
         var val;
         if (def.required) {
             val = _.result(def, 'default');
@@ -677,7 +675,6 @@ function extend(protoProps) {
     var parent = this;
     var child;
     var args = [].slice.call(arguments);
-    var prop, item;
 
     // The constructor function for the new subclass is either defined by you
     // (the "constructor" property in your `extend` definition), or defaulted
@@ -749,8 +746,6 @@ function extend(protoProps) {
             _.extend(child.prototype, def);
         });
     }
-
-    var toString = Object.prototype.toString;
 
     // Set a convenience property in case the parent's prototype is needed
     // later.

--- a/test/basics.js
+++ b/test/basics.js
@@ -127,7 +127,7 @@ test('cached derived properties fire events if result is different', function (t
         }
     });
     var person = new NewPerson({name: 'henrik'});
-    person.on('change:greeting', function (model, value) {
+    person.on('change:greeting', function () {
         t.ok(false, "shouldn't fire if value if derived value is unchanged");
     });
     person.name = 'henrik';
@@ -517,7 +517,7 @@ test("validate on unset and clear", function (t) {
 
 
 test("validate with error callback", function (t) {
-    var lastError, boundError;
+    var boundError;
     var Model = State.extend({
         props: {
             a: 'number',
@@ -528,7 +528,7 @@ test("validate with error callback", function (t) {
     model.validate = function (attrs) {
         if (attrs.admin) return "Can't change admin status.";
     };
-    model.on('invalid', function (model, error) {
+    model.on('invalid', function () {
         boundError = true;
     });
     var result = model.set({a: 100}, {validate: true});

--- a/test/full.js
+++ b/test/full.js
@@ -81,6 +81,7 @@ function reset() {
 }
 
 test('should get the derived value', function (t) {
+    t.plan(2);
     var foo = new Foo({
         firstName: 'jim',
         lastName: 'tom'
@@ -94,6 +95,7 @@ test('should get the derived value', function (t) {
 });
 
 test('should have default values for properties', function (t) {
+    t.plan(2);
     var foo = new Foo({
         firstName: 'jim',
         lastName: 'tom'
@@ -104,6 +106,7 @@ test('should have default values for properties', function (t) {
 });
 
 test('should have default array/object properties', function (t) {
+    t.plan(4);
     var Bar = State.extend({
         props: {
             list: ['array', true],
@@ -151,6 +154,7 @@ test('should throw a useful error setting a default value to an object', functio
 });
 
 test('a default should be settable as a function which returns a value', function (t) {
+    t.plan(1);
     var Foo = State.extend({
         props: {
             anObject: ['object', true, function () { return {foo: 'bar'}; }]
@@ -171,6 +175,7 @@ test('should throw an error setting a derived prop', function (t) {
 });
 
 test('Error when setting derived property should be helpful', function (t) {
+    t.plan(1);
     var foo = new Foo();
     try { foo.name = 'bob'; }
     catch (err) {
@@ -180,6 +185,7 @@ test('Error when setting derived property should be helpful', function (t) {
 });
 
 test('should get correct defaults', function (t) {
+    t.plan(2);
     var foo = new Foo({});
     t.strictEqual(foo.firstName, 'defaults');
     t.strictEqual(foo.thing, 'hi');
@@ -187,6 +193,7 @@ test('should get correct defaults', function (t) {
 });
 
 test('Setting other properties when `extraProperties: "reject"` throws error', function (t) {
+    t.plan(1);
     var Foo = State.extend({
         extraProperties: 'reject'
     });
@@ -200,6 +207,7 @@ test('Setting other properties when `extraProperties: "reject"` throws error', f
 });
 
 test('Setting other properties ignores them by default', function (t) {
+    t.plan(1);
     var foo = new Foo();
     foo.set({
         craziness: 'new'
@@ -209,6 +217,7 @@ test('Setting other properties ignores them by default', function (t) {
 });
 
 test('Setting other properties is ok if extraProperties = "allow"', function (t) {
+    t.plan(1);
     var foo = new Foo();
     foo.extraProperties = 'allow';
     foo.set({
@@ -219,6 +228,7 @@ test('Setting other properties is ok if extraProperties = "allow"', function (t)
 });
 
 test('#11 - multiple instances of the same state class should be able to use extraProperties = "allow" as expected', function (t) {
+    t.plan(5);
     var Foo = State.extend({
         extraProperties: 'allow'
     });
@@ -237,11 +247,11 @@ test('#11 - multiple instances of the same state class should be able to use ext
 });
 
 test('extraProperties = "allow" properties should be defined entirely on the instance not the prototype', function (t) {
+    t.plan(1);
     var Foo = State.extend({
         extraProperties: 'allow'
     });
 
-    var one = new Foo({ a: 'one.a', b: 'one.b' });
     var two = new Foo();
 
     t.deepEqual(two._definition, {});
@@ -249,6 +259,7 @@ test('extraProperties = "allow" properties should be defined entirely on the ins
 });
 
 test('should throw a type error for bad data types', function (t) {
+    t.plan(6);
     t.throws(function () {
         new Foo({firstName: 3});
     }, TypeError);
@@ -272,6 +283,7 @@ test('should throw a type error for bad data types', function (t) {
 });
 
 test('should validate model', function (t) {
+    t.plan(2);
     var foo = new Foo();
     t.equal(foo._verifyRequired(), false);
 
@@ -284,6 +296,7 @@ test('should validate model', function (t) {
 });
 
 test('should store previous attributes', function (t) {
+    t.plan(3);
     var foo = new Foo({
         firstName: 'beau'
     });
@@ -296,6 +309,7 @@ test('should store previous attributes', function (t) {
 });
 
 test('should have data serialization methods', function (t) {
+    t.plan(2);
     var foo = new Foo({
         firstName: 'bob',
         lastName: 'tom',
@@ -321,6 +335,7 @@ test('should have data serialization methods', function (t) {
 });
 
 test('serialize should not include session properties no matter how they\'re defined.', function (t) {
+    t.plan(2);
     var Foo = State.extend({
         props: {
             name: 'string'
@@ -349,6 +364,7 @@ test('serialize should not include session properties no matter how they\'re def
 });
 
 test('should fire events normally for properties defined on the fly', function (t) {
+    t.plan(1);
     var foo = new Foo();
     foo.extraProperties = 'allow';
     foo.on('change:crazyPerson', function () {
@@ -361,6 +377,7 @@ test('should fire events normally for properties defined on the fly', function (
 });
 
 test('should fire event on derived properties, even if dependent on ad hoc prop.', function (t) {
+    t.plan(1);
     var Foo = State.extend({
         extraProperties: 'allow',
         derived: {
@@ -383,6 +400,7 @@ test('should fire event on derived properties, even if dependent on ad hoc prop.
 });
 
 test('should fire general change event on single attribute', function (t) {
+    t.plan(1);
     var foo = new Foo({firstName: 'coffee'});
     foo.on('change', function () {
         t.ok(true);
@@ -392,6 +410,7 @@ test('should fire general change event on single attribute', function (t) {
 });
 
 test('should fire single change event for multiple attribute set', function (t) {
+    t.plan(1);
     var foo = new Foo({firstName: 'coffee'});
     foo.on('change', function () {
         t.ok(true);
@@ -404,6 +423,7 @@ test('should fire single change event for multiple attribute set', function (t) 
 });
 
 test('derived properties', function (t) {
+    t.plan(13);
     var ran = 0;
     var notCachedRan = 0;
     var Foo = State.extend({
@@ -447,6 +467,7 @@ test('derived properties', function (t) {
 });
 
 test('cached, derived properties should only fire change event if they\'ve actually changed', function (t) {
+    t.plan(3);
     var changed = 0;
     var Foo = State.extend({
         props: {
@@ -475,6 +496,7 @@ test('cached, derived properties should only fire change event if they\'ve actua
 });
 
 test('derived properties with derived dependencies', function (t) {
+    t.plan(5);
     var ran = 0;
     var Foo = State.extend({
         props: {
@@ -518,6 +540,7 @@ test('derived properties with derived dependencies', function (t) {
 });
 
 test('derived properties triggered with multiple instances', function (t) {
+    t.plan(2);
     var foo = new Foo({firstName: 'Silly', lastName: 'Fool'});
     var bar = new Foo({firstName: 'Bar', lastName: 'Man'});
 
@@ -533,6 +556,7 @@ test('derived properties triggered with multiple instances', function (t) {
 });
 
 test('Calling `previous` during change of derived cached property should work', function (t) {
+    t.plan(2);
     var foo = new Foo({firstName: 'Henrik', lastName: 'Joreteg'});
     var ran = false;
     foo.on('change:name', function () {
@@ -550,6 +574,7 @@ test('Calling `previous` during change of derived cached property should work', 
 });
 
 test('Calling `previous` during change of derived property that is not cached, should be `undefined`', function (t) {
+    t.plan(1);
     var foo = new Foo({firstName: 'Henrik', lastName: 'Joreteg'});
 
     // the initials property is explicitly not cached
@@ -564,6 +589,7 @@ test('Calling `previous` during change of derived property that is not cached, s
 });
 
 test('Should be able to define and use custom data types', function (t) {
+    t.plan(1);
     var Foo = State.extend({
         props: {
             silliness: 'crazyType'
@@ -590,6 +616,7 @@ test('Should be able to define and use custom data types', function (t) {
 });
 
 test('Uses dataType compare', function (t) {
+    t.plan(2);
     var compareRun;
 
     var Foo = State.extend({
@@ -598,7 +625,7 @@ test('Uses dataType compare', function (t) {
         },
         dataTypes: {
             crazyType: {
-                compare: function (oldVal, newVal) {
+                compare: function () {
                     compareRun = true;
                     return false;
                 },
@@ -626,6 +653,7 @@ test('Uses dataType compare', function (t) {
 });
 
 test('Should only allow nulls where specified', function (t) {
+    t.plan(2);
     var foo = new Foo({
         firstName: 'bob',
         lastName: 'vila',
@@ -639,6 +667,7 @@ test('Should only allow nulls where specified', function (t) {
 });
 
 test('Attribute test function works', function (t) {
+    t.plan(2);
     var foo = new Foo({good: 'good'});
     t.equal(foo.good, 'good');
 
@@ -649,6 +678,7 @@ test('Attribute test function works', function (t) {
 });
 
 test('Values attribute basic functionality', function (t) {
+    t.plan(3);
     var Model = State.extend({
         props: {
             state: {
@@ -672,6 +702,7 @@ test('Values attribute basic functionality', function (t) {
 });
 
 test('Values attribute default works', function (t) {
+    t.plan(2);
     var Model = State.extend({
         props: {
             state: {
@@ -692,6 +723,7 @@ test('Values attribute default works', function (t) {
 });
 
 test('toggle() works on boolean and values properties.', function (t) {
+    t.plan(7);
     var Model = State.extend({
         props: {
             isAwesome: 'boolean',
@@ -726,6 +758,7 @@ test('toggle() works on boolean and values properties.', function (t) {
 });
 
 test('property test function scope is correct.', function (t) {
+    t.plan(1);
     var m;
     var temp;
     var Model = State.extend({
@@ -747,6 +780,7 @@ test('property test function scope is correct.', function (t) {
 });
 
 test('should be able to inherit for use in other objects', function (t) {
+    t.plan(2);
     var StateObj = State.extend({
         props: {
             name: 'string'
@@ -770,6 +804,7 @@ test('should be able to inherit for use in other objects', function (t) {
 });
 
 test('extended state objects should maintain child collections of parents', function (t) {
+    t.plan(2);
     var State1 = State.extend({
         collections: {
             myStuff: Collection
@@ -787,6 +822,7 @@ test('extended state objects should maintain child collections of parents', func
 });
 
 test('`initialize` should have access to initialized child collections', function (t) {
+    t.plan(2);
     var StateObj = State.extend({
         initialize: function () {
             t.ok(this.myStuff);
@@ -797,10 +833,11 @@ test('`initialize` should have access to initialized child collections', functio
             myStuff: Collection
         }
     });
-    var thing = new StateObj();
+    new StateObj();
 });
 
 test('parent collection references should be maintained when adding/removing to a collection', function (t) {
+    t.plan(2);
     var StateObj = State.extend({
         props: {
             id: 'string'
@@ -816,6 +853,7 @@ test('parent collection references should be maintained when adding/removing to 
 });
 
 test('children and collections should be instantiated', function (t) {
+    t.plan(11);
     var GrandChild = State.extend({
         props: {
             id: 'string'
@@ -1030,6 +1068,8 @@ test('Should be able to declare derived properties that have nested deps', funct
         name: 'henrik'
     });
 
+    t.plan(2);
+
     t.equal(first.relationship, 'henrik has grandchild ', 'basics properties working');
 
     first.on('change:relationship', function () {
@@ -1130,7 +1170,8 @@ test('`state` properties should invalidate dependent derived properties when cha
     });
 
     var sub1 = new SubState({id: '1'});
-    var sub2 = new SubState({id: '2'});
+
+    t.plan(6);
 
     t.equal(p.subId, undefined, 'should be undefined to start');
 
@@ -1149,7 +1190,7 @@ test('`state` properties should invalidate dependent derived properties when cha
     sub1.id = 'newId';
 });
 
-test("#1664 - Changing from one value, silently to another, back to original triggers a change.", function (t) {
+test('#1664 - Changing from one value, silently to another, back to original triggers a change.', function (t) {
     var Model = State.extend({
         props: {
             x: 'number'
@@ -1162,7 +1203,7 @@ test("#1664 - Changing from one value, silently to another, back to original tri
     model.set({x: 1});
 });
 
-test("#1664 - multiple silent changes nested inside a change event", function (t) {
+test('#1664 - multiple silent changes nested inside a change event', function (t) {
     var changes = [];
     var Model = State.extend({
         props: {
@@ -1184,7 +1225,7 @@ test("#1664 - multiple silent changes nested inside a change event", function (t
     t.end();
 });
 
-test("silent changes in last `change` event back to original triggers change", function (t) {
+test('silent changes in last `change` event back to original triggers change', function (t) {
     var changes = [];
     var Model = State.extend({
         props: {
@@ -1203,7 +1244,7 @@ test("silent changes in last `change` event back to original triggers change", f
     t.end();
 });
 
-test("#1943 change calculations should use _.isEqual", function (t) {
+test('#1943 change calculations should use _.isEqual', function (t) {
     var Model = State.extend({
         props: {
             a: 'object'
@@ -1215,7 +1256,7 @@ test("#1943 change calculations should use _.isEqual", function (t) {
     t.end();
 });
 
-test("#1964 - final `change` event is always fired, regardless of interim changes", function (t) {
+test('#1964 - final `change` event is always fired, regardless of interim changes', function (t) {
     var Model = State.extend({
         props: {
             property: 'string'
@@ -1232,7 +1273,7 @@ test("#1964 - final `change` event is always fired, regardless of interim change
     model.set('property', 'foo');
 });
 
-test("isValid", function (t) {
+test('isValid', function (t) {
     var Model = State.extend({
         props: {
             valid: 'boolean'
@@ -1251,19 +1292,21 @@ test("isValid", function (t) {
     t.end();
 });
 
-test("#1545 - `undefined` can be passed to a model constructor without coersion", function (t) {
+test('#1545 - `undefined` can be passed to a model constructor without coercion', function (t) {
+    t.plan(1);
     var Model = State.extend({
         defaults: { one: 1 },
-        initialize : function (attrs, opts) {
+        initialize : function (attrs) {
             t.equal(attrs, undefined);
         }
     });
-    var emptyattrs = new Model();
-    var undefinedattrs = new Model(undefined);
+
+    new Model();
+
     t.end();
 });
 
-test("#1961 - Creating a model with {validate: true} will call validate and use the error callback", function (t) {
+test('#1961 - Creating a model with {validate: true} will call validate and use the error callback', function (t) {
     var Model = State.extend({
         props: {
             id: 'number'
@@ -1277,7 +1320,7 @@ test("#1961 - Creating a model with {validate: true} will call validate and use 
     t.end();
 });
 
-test("#2034 - nested set with silent only triggers one change", function (t) {
+test('#2034 - nested set with silent only triggers one change', function (t) {
     var Model = State.extend({
         props: {
             a: 'boolean',
@@ -1293,7 +1336,7 @@ test("#2034 - nested set with silent only triggers one change", function (t) {
     model.set({a: true});
 });
 
-test("#2030 - set with failed validate, followed by another set triggers change", function (t) {
+test('#2030 - set with failed validate, followed by another set triggers change', function (t) {
     var attr = 0, main = 0, error = 0;
     var Model = State.extend({
         props: {
@@ -1315,7 +1358,7 @@ test("#2030 - set with failed validate, followed by another set triggers change"
     t.end();
 });
 
-test("#1179 - isValid returns true in the absence of validate.", function(t) {
+test('#1179 - isValid returns true in the absence of validate.', function(t) {
     var Model = State.extend({
         validate: null
     });
@@ -1324,11 +1367,12 @@ test("#1179 - isValid returns true in the absence of validate.", function(t) {
     t.end();
 });
 
-test("#1791 - `attributes` is available for `parse`", function(t) {
+test('#1791 - `attributes` is available for `parse`', function(t) {
+    t.plan(1);
     var Model = State.extend({
         //Backbone test used this.has which was a this.get !== null test
-        parse: function() { this.get('a') !== null; } // shouldn't throw an error
+        parse: function() { t.ok(this.get('a') !== null); } // shouldn't throw an error
     });
-    var model = new Model(null, {parse: true});
+    new Model(null, {parse: true});
     t.end();
 });

--- a/test/full.js
+++ b/test/full.js
@@ -81,7 +81,6 @@ function reset() {
 }
 
 test('should get the derived value', function (t) {
-    t.plan(2);
     var foo = new Foo({
         firstName: 'jim',
         lastName: 'tom'
@@ -95,7 +94,6 @@ test('should get the derived value', function (t) {
 });
 
 test('should have default values for properties', function (t) {
-    t.plan(2);
     var foo = new Foo({
         firstName: 'jim',
         lastName: 'tom'
@@ -106,7 +104,6 @@ test('should have default values for properties', function (t) {
 });
 
 test('should have default array/object properties', function (t) {
-    t.plan(4);
     var Bar = State.extend({
         props: {
             list: ['array', true],
@@ -154,7 +151,6 @@ test('should throw a useful error setting a default value to an object', functio
 });
 
 test('a default should be settable as a function which returns a value', function (t) {
-    t.plan(1);
     var Foo = State.extend({
         props: {
             anObject: ['object', true, function () { return {foo: 'bar'}; }]
@@ -185,7 +181,6 @@ test('Error when setting derived property should be helpful', function (t) {
 });
 
 test('should get correct defaults', function (t) {
-    t.plan(2);
     var foo = new Foo({});
     t.strictEqual(foo.firstName, 'defaults');
     t.strictEqual(foo.thing, 'hi');
@@ -193,7 +188,6 @@ test('should get correct defaults', function (t) {
 });
 
 test('Setting other properties when `extraProperties: "reject"` throws error', function (t) {
-    t.plan(1);
     var Foo = State.extend({
         extraProperties: 'reject'
     });
@@ -207,7 +201,6 @@ test('Setting other properties when `extraProperties: "reject"` throws error', f
 });
 
 test('Setting other properties ignores them by default', function (t) {
-    t.plan(1);
     var foo = new Foo();
     foo.set({
         craziness: 'new'
@@ -217,7 +210,6 @@ test('Setting other properties ignores them by default', function (t) {
 });
 
 test('Setting other properties is ok if extraProperties = "allow"', function (t) {
-    t.plan(1);
     var foo = new Foo();
     foo.extraProperties = 'allow';
     foo.set({
@@ -228,7 +220,6 @@ test('Setting other properties is ok if extraProperties = "allow"', function (t)
 });
 
 test('#11 - multiple instances of the same state class should be able to use extraProperties = "allow" as expected', function (t) {
-    t.plan(5);
     var Foo = State.extend({
         extraProperties: 'allow'
     });
@@ -247,7 +238,6 @@ test('#11 - multiple instances of the same state class should be able to use ext
 });
 
 test('extraProperties = "allow" properties should be defined entirely on the instance not the prototype', function (t) {
-    t.plan(1);
     var Foo = State.extend({
         extraProperties: 'allow'
     });
@@ -259,7 +249,6 @@ test('extraProperties = "allow" properties should be defined entirely on the ins
 });
 
 test('should throw a type error for bad data types', function (t) {
-    t.plan(6);
     t.throws(function () {
         new Foo({firstName: 3});
     }, TypeError);
@@ -283,7 +272,6 @@ test('should throw a type error for bad data types', function (t) {
 });
 
 test('should validate model', function (t) {
-    t.plan(2);
     var foo = new Foo();
     t.equal(foo._verifyRequired(), false);
 
@@ -296,7 +284,6 @@ test('should validate model', function (t) {
 });
 
 test('should store previous attributes', function (t) {
-    t.plan(3);
     var foo = new Foo({
         firstName: 'beau'
     });
@@ -309,7 +296,6 @@ test('should store previous attributes', function (t) {
 });
 
 test('should have data serialization methods', function (t) {
-    t.plan(2);
     var foo = new Foo({
         firstName: 'bob',
         lastName: 'tom',
@@ -335,7 +321,6 @@ test('should have data serialization methods', function (t) {
 });
 
 test('serialize should not include session properties no matter how they\'re defined.', function (t) {
-    t.plan(2);
     var Foo = State.extend({
         props: {
             name: 'string'
@@ -377,7 +362,6 @@ test('should fire events normally for properties defined on the fly', function (
 });
 
 test('should fire event on derived properties, even if dependent on ad hoc prop.', function (t) {
-    t.plan(1);
     var Foo = State.extend({
         extraProperties: 'allow',
         derived: {
@@ -423,7 +407,6 @@ test('should fire single change event for multiple attribute set', function (t) 
 });
 
 test('derived properties', function (t) {
-    t.plan(13);
     var ran = 0;
     var notCachedRan = 0;
     var Foo = State.extend({
@@ -589,7 +572,6 @@ test('Calling `previous` during change of derived property that is not cached, s
 });
 
 test('Should be able to define and use custom data types', function (t) {
-    t.plan(1);
     var Foo = State.extend({
         props: {
             silliness: 'crazyType'
@@ -616,7 +598,6 @@ test('Should be able to define and use custom data types', function (t) {
 });
 
 test('Uses dataType compare', function (t) {
-    t.plan(2);
     var compareRun;
 
     var Foo = State.extend({
@@ -653,7 +634,6 @@ test('Uses dataType compare', function (t) {
 });
 
 test('Should only allow nulls where specified', function (t) {
-    t.plan(2);
     var foo = new Foo({
         firstName: 'bob',
         lastName: 'vila',
@@ -667,7 +647,6 @@ test('Should only allow nulls where specified', function (t) {
 });
 
 test('Attribute test function works', function (t) {
-    t.plan(2);
     var foo = new Foo({good: 'good'});
     t.equal(foo.good, 'good');
 
@@ -678,7 +657,6 @@ test('Attribute test function works', function (t) {
 });
 
 test('Values attribute basic functionality', function (t) {
-    t.plan(3);
     var Model = State.extend({
         props: {
             state: {
@@ -702,7 +680,6 @@ test('Values attribute basic functionality', function (t) {
 });
 
 test('Values attribute default works', function (t) {
-    t.plan(2);
     var Model = State.extend({
         props: {
             state: {
@@ -723,7 +700,6 @@ test('Values attribute default works', function (t) {
 });
 
 test('toggle() works on boolean and values properties.', function (t) {
-    t.plan(7);
     var Model = State.extend({
         props: {
             isAwesome: 'boolean',
@@ -758,7 +734,6 @@ test('toggle() works on boolean and values properties.', function (t) {
 });
 
 test('property test function scope is correct.', function (t) {
-    t.plan(1);
     var m;
     var temp;
     var Model = State.extend({
@@ -780,7 +755,6 @@ test('property test function scope is correct.', function (t) {
 });
 
 test('should be able to inherit for use in other objects', function (t) {
-    t.plan(2);
     var StateObj = State.extend({
         props: {
             name: 'string'
@@ -804,7 +778,6 @@ test('should be able to inherit for use in other objects', function (t) {
 });
 
 test('extended state objects should maintain child collections of parents', function (t) {
-    t.plan(2);
     var State1 = State.extend({
         collections: {
             myStuff: Collection
@@ -822,7 +795,6 @@ test('extended state objects should maintain child collections of parents', func
 });
 
 test('`initialize` should have access to initialized child collections', function (t) {
-    t.plan(2);
     var StateObj = State.extend({
         initialize: function () {
             t.ok(this.myStuff);
@@ -837,7 +809,6 @@ test('`initialize` should have access to initialized child collections', functio
 });
 
 test('parent collection references should be maintained when adding/removing to a collection', function (t) {
-    t.plan(2);
     var StateObj = State.extend({
         props: {
             id: 'string'
@@ -853,7 +824,6 @@ test('parent collection references should be maintained when adding/removing to 
 });
 
 test('children and collections should be instantiated', function (t) {
-    t.plan(11);
     var GrandChild = State.extend({
         props: {
             id: 'string'
@@ -1293,7 +1263,6 @@ test('isValid', function (t) {
 });
 
 test('#1545 - `undefined` can be passed to a model constructor without coercion', function (t) {
-    t.plan(1);
     var Model = State.extend({
         defaults: { one: 1 },
         initialize : function (attrs) {
@@ -1368,7 +1337,6 @@ test('#1179 - isValid returns true in the absence of validate.', function(t) {
 });
 
 test('#1791 - `attributes` is available for `parse`', function(t) {
-    t.plan(1);
     var Model = State.extend({
         //Backbone test used this.has which was a this.get !== null test
         parse: function() { t.ok(this.get('a') !== null); } // shouldn't throw an error


### PR DESCRIPTION
:wave: Hello &yet! 

After going through the code, I found some parts of the base that could be refactored.

Issue 1: After adding `unused: true` to the `.jshintrc`, there are defined but unused variables.

```sh
ampersand-state.js
  line 78   col 28  'options' is defined but never used.
  line 101  col 13  'triggers' is defined but never used.
  line 298  col 13  'type' is defined but never used.
  line 680  col 9   'prop' is defined but never used.
  line 680  col 15  'item' is defined but never used.
  line 753  col 9   'toString' is defined but never used.

test/basics.js
  line 130   col 51  'value' is defined but never used.
  line 130   col 44  'model' is defined but never used.
  line 520   col 9   'lastError' is defined but never used.
  line 531   col 42  'error' is defined but never used.
  line 531   col 35  'model' is defined but never used.

test/full.js
  line 244   col 9   'one' is defined but never used.
  line 601   col 44  'newVal' is defined but never used.
  line 601   col 36  'oldVal' is defined but never used.
  line 800   col 9   'thing' is defined but never used.
  line 1133  col 9   'sub2' is defined but never used.
  line 1261  col 9   'emptyattrs' is defined but never used.
  line 1262  col 9   'undefinedattrs' is defined but never used.
  line 1257  col 39  'opts' is defined but never used.
  line 1332  col 9   'model' is defined but never used.
```

Issue 2: Because I have set `unused: true`, the tests pass but `jshint` complains because there are variables which are defined but are not used. Within the test, the respective values assigned to the variables are the ones being examined under `testling`.

Issue 3: The test for Issue #1791 is [missing an assertion](https://github.com/francismakes/ampersand-state/compare/AmpersandJS:master...francismakes:master#diff-d52eeda9ba89df3f626cf88a2d2a1879L1330).

Issue 4: Some tests are missing a `t.plan(#)`.

Issue 5: Some test titles are wrapped in double quotes instead of single quotes (not that it really matters...)


This PR:
1. Includes an updated `.jshintrc` with `unused` set to true;
2. Use instances directly without variable assignments (see [here](https://github.com/francismakes/ampersand-state/compare/AmpersandJS:master...francismakes:master#diff-d52eeda9ba89df3f626cf88a2d2a1879R836) and [here](https://github.com/francismakes/ampersand-state/compare/AmpersandJS:master...francismakes:master#diff-d52eeda9ba89df3f626cf88a2d2a1879R1304));
3. Includes `t.plan(#)` where missing; and
4. Updates any and all test names wrapped in double quotes to single quotes.

I didn't see a contributing guide, but am inclined to make the needed revisions where necessary. Please let me know if I'm missing anything too. Thanks in advance!
