### PR TITLE
Optionally include derived and session properties in toJSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,9 +369,14 @@ console.log(me.personID) //=> undefined
 
 **parse** is arguably more useful in ampersand-model, where data typically comes from the server.
 
-### serialize `state.serialize()`
+### serialize `state.serialize([options])`
 
-Serialize the state object into a plain object, ready for sending to the server (typically called via [toJSON](#ampersand-state-tojson)). Of the model's properties, only `props` is returned, `session` and `derived` are omitted. Will also serialize any `children` or `collections` by calling their serialize methods.
+Serialize the state object into a plain object, ready for sending to the server (typically called via [toJSON](#ampersand-state-tojson)). Of the model's properties, only `props` is returned, `session` and `derived` are omitted by default. Will also serialize any `children` or `collections` by calling their serialize methods.
+
+Possible options:
+
+* `session` {Boolean} - whether to include `session` properties in the serialized object.
+* `derived` {Boolean} - whether to include `derived` properties in the serialized object.
 
 
 ### get `state.get(attribute); state[attribute]; state.firstName`
@@ -454,7 +459,7 @@ Determine if the model has been modified since the last `"change"` event. If an 
 
 Return an object containing all the attributes that have changed, or false if there are no changed attributes. Useful for determining what parts of a view need to be updated and/or what attributes need to be persisted to the server. Unset attributes will be set to undefined.  You can also pass an attributes object to diff against the model, determining if there *would be* a change.
 
-### toJSON `state.toJSON()`
+### toJSON `state.toJSON([options])`
 
 Return a shallow copy of the model's attributes for JSON stringification. This can be used for persistence, serialization, or for augmentation before being sent to the server. The name of this method is a bit confusing, as it doesn't actually return a JSON string — but I'm afraid that it's the way that the JavaScript API for JSON.stringify works.
 

--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -82,7 +82,7 @@ _.extend(Base.prototype, BBEvents, {
     // Serialize is the inverse of `parse` it lets you massage data
     // on the way out. Before, sending to server, for example.
     serialize: function (options) {
-        var res = this.getAttributes(_.extend(options || {}, { props: true, session: false }), true);
+        var res = this.getAttributes(_.extend({ props: true }, options), true);
         _.each(this._children, function (value, key) {
             res[key] = this[key].serialize();
         }, this);

--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -81,8 +81,8 @@ _.extend(Base.prototype, BBEvents, {
 
     // Serialize is the inverse of `parse` it lets you massage data
     // on the way out. Before, sending to server, for example.
-    serialize: function () {
-        var res = this.getAttributes({props: true}, true);
+    serialize: function (options) {
+        var res = this.getAttributes(_.extend(options || {}, { props: true, session: false }), true);
         _.each(this._children, function (value, key) {
             res[key] = this[key].serialize();
         }, this);

--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -84,10 +84,10 @@ _.extend(Base.prototype, BBEvents, {
     serialize: function (options) {
         var res = this.getAttributes(_.extend({ props: true }, options), true);
         _.each(this._children, function (value, key) {
-            res[key] = this[key].serialize();
+            res[key] = this[key].serialize(options);
         }, this);
         _.each(this._collections, function (value, key) {
-            res[key] = this[key].serialize();
+            res[key] = this[key].serialize(options);
         }, this);
         return res;
     },

--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -289,8 +289,8 @@ _.extend(Base.prototype, BBEvents, {
         return changed;
     },
 
-    toJSON: function () {
-        return this.serialize();
+    toJSON: function (options) {
+        return this.serialize(options);
     },
 
     unset: function (attr, options) {

--- a/test/full.js
+++ b/test/full.js
@@ -348,7 +348,7 @@ test('serialize should not include session properties no matter how they\'re def
     t.end();
 });
 
-test('serialize should not include session properties even if session is true in options', function (t) {
+test('serialize should include session properties if session is true in options', function (t) {
     var Foo = State.extend({
         props: {
             name: 'string'
@@ -360,7 +360,7 @@ test('serialize should not include session properties even if session is true in
     });
 
     var foo = new Foo({name: 'hi', active: true});
-    t.deepEqual(foo.serialize({session: true}), {name: 'hi'});
+    t.deepEqual(foo.serialize({session: true}), {name: 'hi', active: true});
     t.end();
 });
 
@@ -401,18 +401,6 @@ test('serialize should include derived properties when specified in options.', f
 
     var foo = new Foo({name: 'Hello'});
     t.deepEqual(foo.serialize({derived: true}), {name: 'Hello', greeting: 'Hello, World!'});
-    t.end();
-});
-
-test('serialize should include properties even when props is false in options.', function (t) {
-    var Foo = State.extend({
-        props: {
-            name: 'string'
-        }
-    });
-
-    var foo = new Foo({name: 'Hello'});
-    t.deepEqual(foo.serialize({props: false}), {name: 'Hello'});
     t.end();
 });
 

--- a/test/full.js
+++ b/test/full.js
@@ -1101,7 +1101,7 @@ test('`state` properties', function (t) {
     t.end();
 });
 
-test.only('Issue: #75 `state` property from undefined -> state', function (t) {
+test('Issue: #75 `state` property from undefined -> state', function (t) {
     t.plan(2);
 
     var Person = State.extend({

--- a/test/full.js
+++ b/test/full.js
@@ -348,6 +348,74 @@ test('serialize should not include session properties no matter how they\'re def
     t.end();
 });
 
+test('serialize should not include session properties even if session is true in options', function (t) {
+    var Foo = State.extend({
+        props: {
+            name: 'string'
+        },
+        session: {
+            // simple definintion
+            active: 'boolean'
+        }
+    });
+
+    var foo = new Foo({name: 'hi', active: true});
+    t.deepEqual(foo.serialize({session: true}), {name: 'hi'});
+    t.end();
+});
+
+test('serialize should not include derived properties by default.', function (t) {
+    var Foo = State.extend({
+        props: {
+            name: 'string'
+        },
+        derived: {
+			greeting: {
+	        	deps: ['name'],
+				fn: function() {
+					return this.name + ', World!';
+				}				
+			}
+        }
+    });
+
+    var foo = new Foo({name: 'Hello'});
+    t.deepEqual(foo.serialize(), {name: 'Hello'});
+    t.end();
+});
+
+test('serialize should include derived properties when specified in options.', function (t) {
+    var Foo = State.extend({
+        props: {
+            name: 'string'
+        },
+        derived: {
+			greeting: {
+	        	deps: ['name'],
+				fn: function() {
+					return this.name + ', World!';
+				}				
+			}
+        }
+    });
+
+    var foo = new Foo({name: 'Hello'});
+    t.deepEqual(foo.serialize({derived: true}), {name: 'Hello', greeting: 'Hello, World!'});
+    t.end();
+});
+
+test('serialize should include properties even when props is false in options.', function (t) {
+    var Foo = State.extend({
+        props: {
+            name: 'string'
+        }
+    });
+
+    var foo = new Foo({name: 'Hello'});
+    t.deepEqual(foo.serialize({props: false}), {name: 'Hello'});
+    t.end();
+});
+
 test('should fire events normally for properties defined on the fly', function (t) {
     var foo = new Foo();
     foo.extraProperties = 'allow';

--- a/test/full.js
+++ b/test/full.js
@@ -1422,3 +1422,58 @@ test("#1791 - `attributes` is available for `parse`", function(t) {
     var model = new Model(null, {parse: true});
     t.end();
 });
+
+test("toJSON without options includes only normal properties.", function(t) {
+    var Model = State.extend({
+		props: {
+			name: 'string'
+		},
+		session: {
+			active: 'boolean'
+		},
+		derived: {
+			greeting: {
+				deps: ['name'],
+				fn: function() {
+					return this.name + ', World!';
+				}
+			}
+		}
+    });
+    var model = new Model({name: 'Hello', active: true});
+	t.deepEqual(model.toJSON(), {name: 'Hello'});
+    t.end();
+});
+
+test("toJSON includes session properties when specified in options.", function(t) {
+    var Model = State.extend({
+		props: {
+			name: 'string'
+		},
+		session: {
+			active: 'boolean'
+		}
+    });
+    var model = new Model({name: 'Hello', active: true});
+	t.deepEqual(model.toJSON({session: true}), {name: 'Hello', active: true});
+    t.end();
+});
+
+test("toJSON includes derived properties when specified in options.", function(t) {
+    var Model = State.extend({
+		props: {
+			name: 'string'
+		},
+		derived: {
+			greeting: {
+				deps: ['name'],
+				fn: function() {
+					return this.name + ', World!';
+				}
+			}
+		}
+    });
+    var model = new Model({name: 'Hello'});
+	t.deepEqual(model.toJSON({derived: true}), {name: 'Hello', greeting: 'Hello, World!'});
+    t.end();
+});

--- a/test/full.js
+++ b/test/full.js
@@ -426,6 +426,34 @@ test('serialize should include derived properties when specified in options.', f
     t.end();
 });
 
+test('serialize should include derived properties on children if derived is true in options', function (t) {
+    var Foo = State.extend({
+    	props: {
+    		name: 'string'
+    	},
+        derived: {
+			greeting: {
+	        	deps: ['name'],
+				fn: function() {
+					return this.name + ', World!';
+				}				
+			}
+        }
+    });
+	var Bar = State.extend({
+        props: {
+            name: 'string'
+        },
+		children: {
+			foo: Foo
+		}
+    });
+
+    var bar = new Bar({name: 'hi', foo: {name: 'Hello'}});
+    t.deepEqual(bar.serialize({derived: true}), {name: 'hi', foo: {name: 'Hello', greeting: 'Hello, World!'}});
+    t.end();
+});
+
 test('should fire events normally for properties defined on the fly', function (t) {
     var foo = new Foo();
     foo.extraProperties = 'allow';

--- a/test/full.js
+++ b/test/full.js
@@ -354,13 +354,35 @@ test('serialize should include session properties if session is true in options'
             name: 'string'
         },
         session: {
-            // simple definintion
             active: 'boolean'
         }
     });
 
     var foo = new Foo({name: 'hi', active: true});
     t.deepEqual(foo.serialize({session: true}), {name: 'hi', active: true});
+    t.end();
+});
+
+test('serialize should include session properties on children if session is true in options', function (t) {
+    var Foo = State.extend({
+    	props: {
+    		name: 'string'
+    	},
+		session: {
+			active: 'boolean'
+		}
+    });
+	var Bar = State.extend({
+        props: {
+            name: 'string'
+        },
+		children: {
+			foo: Foo
+		}
+    });
+
+    var bar = new Bar({name: 'hi', foo: {name: 'yo', active: true}});
+    t.deepEqual(bar.serialize({session: true}), {name: 'hi', foo: {name: 'yo', active: true}});
     t.end();
 });
 


### PR DESCRIPTION
Hey &yet!

I'm playing around with using Ampersand in an existing project of mine where I use Hogan mustache templates. The problem I ran into was that `toJSON()` does not include `derived` properties. This makes perfect sense when saving data to the server, but when using `toJSON()` to create a view model to be rendered I've found it limiting.

For example, if I have a `User` model with a `username` property, I might also have a `derived` property `profileURL` that uses the `username` to generate the URL of their profile page. When I render my view, I want to send both the `username` and `profileURL` properties to the template, but by default `toJSON()` only includes `username`. By allowing `toJSON()` (and by extension `serialize()`) to accept an `options` object, I can now optionally include `derived` properties (e.g. `toJSON({derived: true})`).

```javascript
var User = AmpersandState.extend({
    props: {
        username: 'string'
    },
    derived: {
        profileURL: {
            deps: ['username'],
            fn: function() {
                return '/profile/' + this.username;
            }
        }
    }
});
```

```mustache
<a href="{{profileURL}}">{{username}}</a>
```