### PR TITLE
Improved the error message for enumerated values

### DIFF
--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -184,7 +184,7 @@ _.extend(Base.prototype, BBEvents, {
                 throw new TypeError('Property \'' + attr + '\' must be of type ' + def.type + '. Tried to set ' + newVal);
             }
             if (def.values && !_.contains(def.values, newVal)) {
-                throw new TypeError('Property \'' + attr + '\' must be one of values: ' + def.values.join(', '));
+                throw new TypeError('Property \'' + attr + '\' must be one of values: ' + def.values.join(', ') + '. Tried to set ' + newVal);
             }
 
             hasChanged = !isEqual(currentVal, newVal, attr);


### PR DESCRIPTION
I ran into the situation where I set a collection with lots of models at once, but this failed due to value constraints on the model. To find out which model failed, I needed a hint. This might be useful for others too.
