### PR TITLE
fix for #82 child collections getting their data wiped if they add it to themselves

### DIFF
--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -427,7 +427,7 @@ _.extend(Base.prototype, BBEvents, {
         var coll;
         if (!this._collections) return;
         for (coll in this._collections) {
-            this[coll] = new this._collections[coll]([], {parent: this});
+            this[coll] = new this._collections[coll](null, {parent: this});
         }
     },
 

--- a/test/full.js
+++ b/test/full.js
@@ -910,6 +910,32 @@ test('children and collections should be instantiated', function (t) {
     t.end();
 });
 
+test('issue #82, child collections should not be cleared if they add data to themselves when instantiated', function (t) {
+    var Widget = State.extend({
+        props: {
+            title: 'string'
+        }
+    });
+    var Widgets = Collection.extend({
+        initialize: function () {
+            // some collections read from data they have immediate access to
+            // like localstorage, or whatnot. This should not be wiped out
+            // when instantiated by parent.
+            this.add([{title: 'hi'}]);
+        },
+        model: Widget
+    });
+    var Parent = State.extend({
+        collections: {
+            widgets: Widgets
+        }
+    });
+    var parent = new Parent();
+
+    t.equal(parent.widgets.length, 1, 'should contain data added by initialize method of child collection');
+    t.end();
+});
+
 test('listens to child events', function (t) {
     var GrandChild = State.extend({
         props: {


### PR DESCRIPTION
I think this one's pretty cut and dried. Simple change, patch version update.
