### PR TITLE
update _getEventBubblingHandler

### DIFF
--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -446,6 +446,7 @@ _.extend(Base.prototype, BBEvents, {
         return _.bind(function (name, model, newValue) {
             if (changeRE.test(name)) {
                 this.trigger('change:' + propertyName + '.' + name.split(':')[1], model, newValue);
+                this.trigger('change:' + propertyName, model, newValue)
             } else if (name === 'change') {
                 this.trigger('change', this);
             }


### PR DESCRIPTION
triggers a 'change:propertyName' without specifying the attribute that was changed

Useful when you have a property with nested values, want to listen for any attribute changes, and don't want to create listeners every single attribute.
