### PR TITLE
silent:false when setting child collections during initial set

### DIFF
--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -139,9 +139,13 @@ _.extend(Base.prototype, BBEvents, {
 
 
             if (!def) {
-                // if this is a child model or collection
-                if (this._children[attr] || this._collections[attr]) {
+                // if this is a child model
+                if (this._children[attr]) {
                     this[attr].set(newVal, options);
+                    continue;
+                // if it is a collection set silent to false during initial set
+                } else if (this._collections[attr]) {
+                    this[attr].set(newVal, options.silent && options.initial ? _.extend(options, {silent: false}) : options);
                     continue;
                 } else if (extraProperties === 'ignore') {
                     continue;

--- a/test/full.js
+++ b/test/full.js
@@ -1392,3 +1392,27 @@ test("#1791 - `attributes` is available for `parse`", function(t) {
     var model = new Model(null, {parse: true});
     t.end();
 });
+
+test("child collections call add on init", function(t) {
+    var MyCollection = Collection.extend({
+        model: State.extend({
+            props: {
+                id: 'string'
+            }
+        }),
+        initialize: function () {
+            this.listenTo(this, 'add', function (model) {
+                t.equal(model.id, '1');
+                t.end();
+            });
+        }
+    });
+    var Model = State.extend({
+        collections: {
+            items: MyCollection
+        }
+    });
+    var model = new Model({
+        items: [{id: '1'}]
+    });
+});


### PR DESCRIPTION
Came upon this when I was trying to fetch a collection of models, where each model had a child collection, but the initial add events were never being called.

I understand the reasoning that the constructor calls set with `silent:true` and I think that should be respected by passing it to child models and change events, but I was expecting add events to be fired on child collections. Am I wrong? Or is there a workaround for this that I'm missing?
