### PR TITLE
allow default prop of `idAttribute` when none defined.   

### DIFF
--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -754,6 +754,11 @@ function extend(protoProps) {
         });
     }
 
+    // if no `idAttribute` property defined yet, then define one as a default
+    if(!Object.getOwnPropertyDescriptor(child.prototype,child.prototype.idAttribute)){
+        createPropertyDefinition(child.prototype, child.prototype.idAttribute, 'any');
+    }
+    // should toString be removed???  it's an unused variable...
     var toString = Object.prototype.toString;
 
     // Set a convenience property in case the parent's prototype is needed

--- a/test/basics.js
+++ b/test/basics.js
@@ -230,6 +230,23 @@ test('custom id and namespace attributes', function (t) {
     t.end();
 });
 
+test('no idAttribute prop defined still can use id ', function(t) {
+    var NewPerson = State.extend();
+    var person = new NewPerson({id: '47'});
+    t.equal(person.getId(), '47');
+    t.end();
+});
+
+test('custom idAttribute but no prop defined', function(t){
+    var NewPerson = State.extend({
+        idAttribute: '_id'
+    });
+    var person = new NewPerson({_id: 47});
+    t.equal(person.getId(), 47);
+    t.end();
+});
+
+
 test('customizable `type` attribute', function (t) {
     var FirstModel = State.extend({
         type: 'hello',


### PR DESCRIPTION
Proposed fix for #93 with passing tests.  

I went with the 'any' property for the default.  Not sure if that was the best idea or not. 

note extra comment on the `toString` variable.   Looks like it could be removed... 
