### PR TITLE
Don’t delete properties from mixin objects passed to .extend

### DIFF
--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -720,43 +720,40 @@ function extend(protoProps) {
     // Mix in all prototype properties to the subclass if supplied.
     if (protoProps) {
         args.forEach(function processArg(def) {
+            var omitFromExtend = [
+                'dataTypes', 'props', 'session', 'derived', 'collections', 'children'
+            ];
             if (def.dataTypes) {
                 _.each(def.dataTypes, function (def, name) {
                     child.prototype._dataTypes[name] = def;
                 });
-                delete def.dataTypes;
             }
             if (def.props) {
                 _.each(def.props, function (def, name) {
                     createPropertyDefinition(child.prototype, name, def);
                 });
-                delete def.props;
             }
             if (def.session) {
                 _.each(def.session, function (def, name) {
                     createPropertyDefinition(child.prototype, name, def, true);
                 });
-                delete def.session;
             }
             if (def.derived) {
                 _.each(def.derived, function (def, name) {
                     createDerivedProperty(child.prototype, name, def);
                 });
-                delete def.derived;
             }
             if (def.collections) {
                 _.each(def.collections, function (constructor, name) {
                     child.prototype._collections[name] = constructor;
                 });
-                delete def.collections;
             }
             if (def.children) {
                 _.each(def.children, function (constructor, name) {
                     child.prototype._children[name] = constructor;
                 });
-                delete def.children;
             }
-            _.extend(child.prototype, def);
+            _.extend(child.prototype, _.omit(def, omitFromExtend));
         });
     }
 

--- a/test/full.js
+++ b/test/full.js
@@ -1474,3 +1474,22 @@ test("#99 #101 - string dates can be parsed", function(t) {
 
     t.end();
 });
+
+test('#68, #110 mixin props should not be deleted', function (t) {
+    var SelectedMixin = {
+      session : {
+        selected : 'boolean'
+      }
+    };
+
+    var Widget = State.extend(SelectedMixin,{});
+    t.deepEqual(SelectedMixin.session, { selected: 'boolean' });
+    var Sprocket = State.extend(SelectedMixin,{});
+
+    var widget = new Widget({selected : true});
+    var sprocket = new Sprocket({selected : true});
+
+    t.ok(widget.selected);
+    t.ok(sprocket.selected);
+    t.end();
+});


### PR DESCRIPTION
Fixes: #68, #110
