### PR TITLE
idempotent computed default properties

### DIFF
--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -545,7 +545,9 @@ function createPropertyDefinition(object, name, desc, isSession) {
                 }
                 return result;
             }
-            return _.result(def, 'default');
+            result = _.result(def, 'default');
+            this._values[name] = result;
+            return result;
         }
     });
 

--- a/test/full.js
+++ b/test/full.js
@@ -685,25 +685,41 @@ test('Values attribute basic functionality', function (t) {
     t.end();
 });
 
-test('Values attribute default works', function (t) {
+test('Values attribute default works and is called only once', function (t) {
+    var ran = 0;
     var Model = State.extend({
+        dataTypes: {
+            countryType: {
+                default: 'Atlantis'
+            }
+        },
         props: {
+            country: {
+                type: 'countryType',
+                required: true
+            },
             state: {
                 values: ['CA', 'WA', 'NV'],
-                default: 'CA'
+                default: function(){
+                    ran++;
+                    return 'CA';
+                }
             }
         }
     });
 
     var m = new Model();
-
     t.equal(m.state, 'CA', 'Should have applied the default');
-
+    t.equal(ran, 1, 'Should have been invoked only once');
+    t.equal(m.state, 'CA', 'Should have returned the same object');
+    t.equal(ran, 1, 'Should have been invoked only once');
+    t.equal(m.country, 'Atlantis');
     t.throws(function () {
         m.state = 'PR';
     }, TypeError, 'Throws exception when setting something not in list');
     t.end();
 });
+
 
 test('toggle() works on boolean and values properties.', function (t) {
     var Model = State.extend({


### PR DESCRIPTION
When a default value or function is provided for a property, state should only
consult the default once.  It should then set the value from the default and
return that value on subsequent calls.

Corrects issues #60, but may need more refinement.  This does not call `set` to
store the value, rather it simply stores it by directly manipulating the _values
object.

I'm conflicted if it should call `set` to store the value or not.  If it did so, then there's
a possibility that it would throw an exception if it sets a non-valid value.

Doing so would would also fire a "change" event that might be unwanted.

It might also be called before the object is completely initialized and is missing the _change
object.  In that case an outright error is encountered. I believe thats the cause of the
exceptions that @francismakes noted in the comments for #60.  That can be worked around,
but is a bit more involved that we'd perhaps want it to be.

At any rate, I consider this a starting point to resolving the issue and am happy to rework in response
to comments.
