### PR TITLE
Don’t fallback to a datatype default value if setOnce is true. [semi-urgent]

### DIFF
--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -524,7 +524,7 @@ function createPropertyDefinition(object, name, desc, isSession) {
 
         def.allowNull = desc.allowNull ? desc.allowNull : false;
         if (desc.setOnce) def.setOnce = true;
-        if (def.required && _.isUndefined(def.default)) def.default = object._getDefaultForType(type);
+        if (def.required && _.isUndefined(def.default) && !def.setOnce) def.default = object._getDefaultForType(type);
         def.test = desc.test;
         def.values = desc.values;
     }

--- a/test/full.js
+++ b/test/full.js
@@ -1509,3 +1509,25 @@ test('#68, #110 mixin props should not be deleted', function (t) {
     t.ok(sprocket.selected);
     t.end();
 });
+
+test('#114 setOnce allows values to be set once and only once', function (t) {
+    var Model = State.extend({
+        props: {
+            x: {
+                type: 'string',
+                setOnce: true,
+                required: true,
+            }
+        }
+    });
+
+    var model = new Model({ x: 'foo' });
+
+    t.equal(model.x, 'foo');
+
+    t.throws(function () {
+        model.x = 'bar';
+    }, /can only be set once/);
+
+    t.end();
+});


### PR DESCRIPTION
This fixes an issue caused by #114 and raised in the comments there.

Currently a field definition like:

``` js
props: {
  foo: {
    type: 'string',
    setOnce: true,
    required: true 
  }
}
```

creates a property that can never be set, as the default gets pulled off the datatype and set as the field default, and it can never be set to a "real" value without raising an exception.

I've changed the behaviour such that if setOnce is true, then the dataType default will never be used as a fallback value for the default, which I think makes sense, as setOnce with a default value is pretty weird anyway, especially if the default is `""` or something that came from the dataType.
