### PR TITLE
Don’t coerce a date type set with `null` to be 1970.

### DIFF
--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -613,7 +613,7 @@ var dataTypes = {
             };
         },
         get: function (val) {
-            if (val == null ) {
+            if (val == null) {
                 return undefined;
             } else {
                 return new Date(val);

--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -587,7 +587,9 @@ var dataTypes = {
     date: {
         set: function (newVal) {
             var newType;
-            if (!_.isDate(newVal)) {
+            if (newVal == null) {
+                newType = typeof null;
+            } else if (!_.isDate(newVal)) {
                 try {
                     var dateVal = new Date(newVal).valueOf();
                     if (isNaN(dateVal)) {
@@ -604,13 +606,18 @@ var dataTypes = {
                 newType = 'date';
                 newVal = newVal.valueOf();
             }
+
             return {
                 val: newVal,
                 type: newType
             };
         },
         get: function (val) {
-            return new Date(val);
+            if (val == null ) {
+                return undefined;
+            } else {
+                return new Date(val);
+            }
         },
         default: function () {
             return new Date();

--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -613,11 +613,8 @@ var dataTypes = {
             };
         },
         get: function (val) {
-            if (val == null) {
-                return undefined;
-            } else {
-                return new Date(val);
-            }
+            if (val == null) { return val; }
+            return new Date(val);
         },
         default: function () {
             return new Date();

--- a/test/full.js
+++ b/test/full.js
@@ -1500,6 +1500,11 @@ test('#128 don\'t coerce null date as 0', function (t) {
 
     var day = new Day({ theDate: null });
     t.notOk(day.theDate, 'date should not be set if null');
+    t.equal(day.theDate, null);
+
+    day = new Day({ theDate: undefined });
+    t.notOk(day.theDate, 'date should not be set if undefined');
+    t.equal(day.theDate, undefined);
 
     var Day2 = State.extend({
         props: {

--- a/test/full.js
+++ b/test/full.js
@@ -1499,7 +1499,22 @@ test('#128 don\'t coerce null date as 0', function (t) {
     });
 
     var day = new Day({ theDate: null });
-    t.notOk(day.theDate);
+    t.notOk(day.theDate, 'date should not be set if null');
+
+    var Day2 = State.extend({
+        props: {
+            theDate: {
+                type: 'date',
+                required: true,
+                allowNull: false
+            }
+        }
+    });
+
+    t.throws(function () {
+        new Day2({ theDate: null });
+    }, /cannot be null/, 'if allowNull:false, and required:true should still throw');
+
     t.end();
 });
 

--- a/test/full.js
+++ b/test/full.js
@@ -1491,6 +1491,18 @@ test("#99 #101 - string dates can be parsed", function(t) {
     t.end();
 });
 
+test('#128 don\'t coerce null date as 0', function (t) {
+    var Day = State.extend({
+        props: {
+            theDate: 'date'
+        }
+    });
+
+    var day = new Day({ theDate: null });
+    t.notOk(day.theDate);
+    t.end();
+});
+
 test('#68, #110 mixin props should not be deleted', function (t) {
     var SelectedMixin = {
       session : {


### PR DESCRIPTION
fixes #128 

Since we try and coerce in both get and set I think we need this in both places.