### PR TITLE
use deep quality comparison for derived updates

### DIFF
--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -386,8 +386,19 @@ _.extend(Base.prototype, BBEvents, {
                 options = options || {};
 
                 var newVal = def.fn.call(self);
+                var newValToCompare, cachedValToCompare;
 
-                if (self._cache[name] !== newVal || !def.cache) {
+                // in case the data has a toJSON val, e.g. a Model, use that for comparison
+                if (newVal.toJSON && self._cache[name].toJSON) {
+                    newValToCompare = newVal.toJSON();
+                    cachedValToCompare = self._cache[name].toJSON();
+                }
+                else {
+                    newValToCompare = newVal;
+                    cachedValToCompare = self._cache[name];
+                }
+
+                if (!_.isEqual(newValToCompare, cachedValToCompare) || !def.cache) {
                     if (def.cache) {
                         self._previousAttributes[name] = self._cache[name];
                     }


### PR DESCRIPTION
Instead of using strict comparison on derived property changes, uses the `_.isEqual` method. Helps prevent triggering unnecessary change events when a derived property is not a primitive data type.