### PR TITLE
Custom dataType updates

### DIFF
--- a/test/full.js
+++ b/test/full.js
@@ -1474,3 +1474,42 @@ test("#99 #101 - string dates can be parsed", function(t) {
 
     t.end();
 });
+
+test("#112 - should not set up events on child state if setOnce check fails", function(t){
+    var Person = State.extend({
+        props : {
+            birthday : {
+                type : 'state',
+                setOnce : true
+            }
+        }
+    });
+
+    var Birthday = State.extend({
+        props : {
+            day : 'date'
+        }
+    });
+    var p = new Person();
+    var bday = new Birthday({day : new Date()});
+    p.once('change:birthday', function() {
+        t.pass('birthday can change once');
+    });
+    p.birthday = bday;
+    var newBday = new Birthday({day : new Date()});
+    t.throws(function() {
+        p.birthday = newBday;
+
+    }, TypeError, 'Throws error on change of setOnce');
+
+    p.on('change:birthday.day', function() {
+        t.fail('should not trigger change event on old one');
+    });
+
+    newBday.day = new Date(1);
+
+
+    t.end();
+
+
+});


### PR DESCRIPTION
Fixes a bug vaguely referenced in #112 where listening to events could be messed up when using `setOnce`. 

It also: 
*  makes the `set` call be bound to `this`, which makes the call more powerful (this is also referenced in #112)
*  creates an `onSet` method for custom datatypes, which is designed to allow for initialization of custom datatypes after they pass all their tests (type check, `setOnce`, etc) but before events are called.  Case here is for `state` type setting up child event bubbling.
*  updates for the state `compare` method to only do compare, child bubbling moved to new `onSet` method.  

Currently does not update docs.  #112 has been out there for awhile so I'm not sure how well this PR will be received.  However, if I get interest from the core team, I'll update the docs to reflect the new changes.  I'll even throw in some documentation for the `state` datatype (from #142 ). :) 