### PR TITLE
update key-tree-store

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "ampersand-version": "^1.0.0",
     "array-next": "~0.0.1",
     "backbone-events-standalone": "0.2.2",
-    "key-tree-store": "~0.1.0",
+    "key-tree-store": "^1.2.0",
     "lodash.assign": "^3.0.0",
     "lodash.bind": "^3.1.0",
     "lodash.clone": "^3.0.1",


### PR DESCRIPTION
This will no longer warn `unavoidable conflict Not de-duplicating` from npm when trying to dedupe with projects also containing `ampersand-view`.