### PR TITLE
add documentation for getAttributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,41 +620,42 @@ me.toJSON() //=> { firstName: 'Phil', lastName: 'Roberts' }
 JSON.stringify(me) //=> "{\"firstName\":\"Phil\",\"lastName\":\"Roberts\"}"
 ```
 
-### getAttributes `state.getAttributes([options])`
+### getAttributes `state.getAttributes([options, raw])`
 
-Returns a shallow copy of the state's attributes while only including the types (props, session, derived) specified by the `options` parameter. The desired keys should be set to `true` on `options` (`props`, `session`, `derived`) if attributes of that type should be returned by `getAttributes`.
+Returns a shallow copy of the state's attributes while only including the types (props, session, derived) specified by the `options` parameter. The desired keys should be set to `true` on `options` (`props`, `session`, `derived`) if attributes of that type should be returned by `getAttributes`. The second parameter, `raw`, is a boolean that specifies whether returned values should be the raw value or should instead use the getter associated with its data type.
 
 ```javascript
 var Person = AmpersandState.extend({
-    props: {
-        firstName: 'string',
-        lastName: 'string'
-    },
-    session: {
-      active: 'boolean'
-    },
-    derived: {
-      fullName: {
-        deps: ['firstName', 'lastName'],
-        fn: function () {
-          return this.firstName + ' ' + this.lastName;
-        }
+  props: {
+      firstName: 'string',
+      lastName: 'string'
+  },
+  session: {
+    lastSeen: 'date',
+    active: 'boolean'
+  },
+  derived: {
+    fullName: {
+      deps: ['firstName', 'lastName'],
+      fn: function () {
+        return this.firstName + ' ' + this.lastName;
       }
     }
   }
 });
 
-var me = new Person({ firstName: 'Luke', lastName: 'Karrys', active: true });
+var me = new Person({ firstName: 'Luke', lastName: 'Karrys', active: true, lastSeen: 1428430444479 });
 
 me.getAttributes({derived: true}) //=> { fullName: 'Luke Karrys' }
 
-me.getAttributes({session: true}) //=> { active: true }
+me.getAttributes({session: true}) //=> { active: true, lastSeen: Tue Apr 07 2015 11:14:04 GMT-0700 (MST) }
+me.getAttributes({session: true}, true) //=> { active: true, lastSeen: 1428430444479 }
 
 me.getAttributes({
   props: true,
   session: true,
   derived: true
-}) //=> { firstName: 'Luke', lastName: 'Karrys', active: true, fullName: 'Luke Karrys' }
+}) //=> { firstName: 'Luke', lastName: 'Karrys', active: true, lastSeen: Tue Apr 07 2015 11:14:04 GMT-0700 (MST), fullName: 'Luke Karrys' }
 ```
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -620,6 +620,43 @@ me.toJSON() //=> { firstName: 'Phil', lastName: 'Roberts' }
 JSON.stringify(me) //=> "{\"firstName\":\"Phil\",\"lastName\":\"Roberts\"}"
 ```
 
+### getAttributes `state.getAttributes([options])`
+
+Returns a shallow copy of the state's attributes while only including the types (props, session, derived) specified by the `options` parameter. The desired keys should be set to `true` on `options` (`props`, `session`, `derived`) if attributes of that type should be returned by `getAttributes`.
+
+```javascript
+var Person = AmpersandState.extend({
+    props: {
+        firstName: 'string',
+        lastName: 'string'
+    },
+    session: {
+      active: 'boolean'
+    },
+    derived: {
+      fullName: {
+        deps: ['firstName', 'lastName'],
+        fn: function () {
+          return this.firstName + ' ' + this.lastName;
+        }
+      }
+    }
+  }
+});
+
+var me = new Person({ firstName: 'Luke', lastName: 'Karrys', active: true });
+
+me.getAttributes({derived: true}) //=> { fullName: 'Luke Karrys' }
+
+me.getAttributes({session: true}) //=> { active: true }
+
+me.getAttributes({
+  props: true,
+  session: true,
+  derived: true
+}) //=> { firstName: 'Luke', lastName: 'Karrys', active: true, fullName: 'Luke Karrys' }
+```
+
 ## Changelog
 
 <!-- starthide -->

--- a/README.md
+++ b/README.md
@@ -622,7 +622,9 @@ JSON.stringify(me) //=> "{\"firstName\":\"Phil\",\"lastName\":\"Roberts\"}"
 
 ### getAttributes `state.getAttributes([options, raw])`
 
-Returns a shallow copy of the state's attributes while only including the types (props, session, derived) specified by the `options` parameter. The desired keys should be set to `true` on `options` (`props`, `session`, `derived`) if attributes of that type should be returned by `getAttributes`. The second parameter, `raw`, is a boolean that specifies whether returned values should be the raw value or should instead use the getter associated with its data type.
+Returns a shallow copy of the state's attributes while only including the types (props, session, derived) specified by the `options` parameter. The desired keys should be set to `true` on `options` (`props`, `session`, `derived`) if attributes of that type should be returned by `getAttributes`.
+
+The second parameter, `raw`, is a boolean that specifies whether returned values should be the raw value or should instead use the getter associated with its data type. If you are using `getAttributes` to pass data to a template, most of the time you will not want to use the `raw` parameter, since you will want to take advantage of any built-in and custom data types on your state instance.
 
 ```javascript
 var Person = AmpersandState.extend({


### PR DESCRIPTION
Add a section to the documentation explaining `getAttributes`.

Not quite ready for merge since I'm not actually sure what the second parameter (`raw`) should be used for (or if should be left undocumented). Anyone have any insights there?