### PR TITLE
Calling toJSON-func of child-models and -collections in stead of theirs serialize-func

### DIFF
--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -107,10 +107,10 @@ assign(Base.prototype, Events, {
     serialize: function () {
         var res = this.getAttributes({props: true}, true);
         forEach(this._children, function (value, key) {
-            res[key] = this[key].serialize();
+            res[key] = this[key].toJSON();
         }, this);
         forEach(this._collections, function (value, key) {
-            res[key] = this[key].serialize();
+            res[key] = this[key].toJSON();
         }, this);
         return res;
     },

--- a/test/full.js
+++ b/test/full.js
@@ -1685,11 +1685,27 @@ test('#175 - calling toJSON-func from child-models and -collections in stead of 
         }
     });
 
-    var a = new MyState();
-    var obj = a.toJSON();
+    var a = new MyState({
+        test1: true,
+        myChild: {
+            test1: true
+        },
+        myCollection: [{
+            test1: true
+        },{
+            test1: true
+        }]
+    });
+    var json = a.toJSON();
+    var serialized = a.serialize();
 
     t.equal(testChild, true);
     t.equal(testCollection, true);
+    t.deepEqual(json,serialized);
+    t.deepEqual(a.myChild.toJSON(),a.myChild.serialize());
+    t.deepEqual(json.myChild,a.myChild.serialize());
+    t.deepEqual(json.myChild,a.myChild.toJSON());
+    t.deepEqual(json.myCollection[0],a.myCollection.models[0].serialize());
 
     t.end();
 });

--- a/test/full.js
+++ b/test/full.js
@@ -1653,3 +1653,44 @@ test('throw helpful error if trying to extend with `prop` that already is define
 
     t.end();
 });
+
+test('#175 - calling toJSON-func from child-models and -collections in stead of theirs serialize-func', function (t) {
+    var testChild = false;
+    var testCollection = false;
+    var MyChild = State.extend({
+        props: {
+            test1: ['boolean', true, true],
+        },
+        toJSON: function () {
+            testChild = true;
+            return this.serialize();
+        }
+    });
+    var MyCollection = Collection.extend({
+        model: MyChild,
+        toJSON: function () {
+            testCollection = true;
+            return this.serialize();
+        }
+    });
+    var MyState = State.extend({
+        props: {
+            test1: ['boolean', true, true]
+        },
+        children: {
+            myChild: MyChild
+        },
+        collections: {
+            myCollection: MyCollection
+        }
+    });
+
+    var a = new MyState();
+    var obj = a.toJSON();
+
+    t.equal(testChild, true);
+    t.equal(testCollection, true);
+
+    t.end();
+});
+


### PR DESCRIPTION
When calling the toJSON-func of a model, it actually calls the serialize-func. This allows you to overwrite the toJSON-func... 
The resulting object contains the "serialize"-function result of its Child-models and -collections. It would be better if all of their toJSON-functions would be used.