### PR TITLE
added postInitialize

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,48 @@ Available options:
 * `[parse]` {Boolean} - whether to call the class's [parse](#ampersand-state-parse) function with the initial attributes. _Defaults to `false`_.
 * `[parent]` {AmpersandState} - pass a reference to a state's parent to store on the state.
 
+### postInitialize `state.postInitialize()`
+
+If you have defined a `postInitialize` function for your subclass of State, it will be invoked at creation time, just after it's parent or (parent-)collection `initialize` functions has been triggerd.
+
+```
+var DateOfBirth = AmpsersandModel.extend({
+    props: {
+        day: 'number',
+        month: 'number',
+        year: 'number'
+    },
+    postInitialize: function() {
+        console.log('run code AFTER the initialize function of this.parent');
+    }
+});
+
+var Siblings = AmpserandCollection.extend({
+    model: Person,
+    postInitialize: function() {
+        console.log('run code AFTER the initialize function of this.parent');
+    }
+});
+
+var Person = AmpersandModel.extend({
+    props: {
+        name: 'string'
+    },
+    child: {
+        dateOfBirth: DateOfBirth
+    },
+    collections: {
+        siblings: Siblings
+    },
+    initalize: function() {
+        console.log('run code that can be used in the postInitialize-function of my children');
+    }
+});
+
+var me = new Person({ name: 'John', dateOfBirth: { day: 6, month: 10, year: 1981 }, siblings: [{...},{...},{...}] });
+
+```
+
 ### idAttribute `state.idAttribute`
 
 The attribute that should be used as the unique id of the state. `getId` uses this to determine the `id` for use when constructing a model's `url` for saving to the server.

--- a/README.md
+++ b/README.md
@@ -85,40 +85,57 @@ Available options:
 If you have defined a `postInitialize` function for your subclass of State, it will be invoked at creation time, just after it's parent or (parent-)collection `initialize` functions has been triggerd.
 
 ```
-var DateOfBirth = AmpsersandModel.extend({
+var State = require('ampersand-state');
+var Collection = require('ampersand-collection');
+
+var Widget = State.extend({
     props: {
-        day: 'number',
-        month: 'number',
-        year: 'number'
+        name: 'string',
+        funLevel: 'number'
     },
     postInitialize: function() {
-        console.log('run code AFTER the initialize function of this.parent');
+        console.log('code to run just AFTER this.parent.initialize has been invoked');
     }
 });
 
-var Siblings = AmpserandCollection.extend({
-    model: Person,
+var Hat = State.extend({
+    props: {
+        color: 'string'
+    },
     postInitialize: function() {
-        console.log('run code AFTER the initialize function of this.parent');
+        console.log('code to run just AFTER this.parent.initialize has been invoked');
     }
 });
 
-var Person = AmpersandModel.extend({
+var WidgetCollection = Collection.extend({
+    model: Widget,
+    postInitialize: function() {
+        console.log('code to run just AFTER this.parent.initialize has been invoked');
+    }
+});
+
+var Person = AmpersandState.extend({
     props: {
         name: 'string'
     },
-    child: {
-        dateOfBirth: DateOfBirth
-    },
+    children: {
+        hat: Hat
+    }
     collections: {
-        siblings: Siblings
-    },
-    initalize: function() {
-        console.log('run code that can be used in the postInitialize-function of my children');
+        widgets: WidgetCollection
     }
 });
 
-var me = new Person({ name: 'John', dateOfBirth: { day: 6, month: 10, year: 1981 }, siblings: [{...},{...},{...}] });
+var me = new Person({
+    name: 'Bob',
+    hat: {
+        color: 'red'
+    }
+    widgets: [
+        { name: 'music', funLevel: 10 },
+        { name: 'coding', funLevel: 10 }
+    ]
+});
 
 ```
 

--- a/test/full.js
+++ b/test/full.js
@@ -1653,3 +1653,67 @@ test('throw helpful error if trying to extend with `prop` that already is define
 
     t.end();
 });
+
+test('Add a postInitialize-functionality over States and Collections, Children and subCollections', function (t) {
+    var result = [];
+    /**** Model Test *****/
+    var MyModel = State.extend({
+        props: {
+            val: 'number'
+        },
+        initialize: function() {
+            result.push(this.val);
+        },
+        postInitialize: function() {
+            result.push(this.val);
+        }
+    });
+
+    /**** Collection Test *****/
+    var MyCollection = Collection.extend({
+        model: MyModel,
+        initialize: function() {
+            result.push(-1);
+        },
+        postInitialize: function() {
+            result.push(-1);
+        }
+    });
+
+    var App = State.extend({
+        props: {
+            val: 'number'
+        },
+        children: {
+            myChild: MyModel
+        },
+        collections: {
+            myColl: MyCollection
+        },
+        initialize: function(props) {
+            result.push(this.val);
+        },
+        postInitialize: function() {
+            result.push(this.val);
+        }
+    });
+
+    var a = new App({
+        val: 0,
+        myChild: {
+            val: 1
+        },
+        myColl: [{
+            val: 2
+        }, {
+            val: 3
+        }, {
+            val: 4
+        }]
+    });
+    t.deepEqual(result, [ -1, 2, 3, 4, 1, 0, 1, 2, 3, 4, -1, 0 ]);
+
+    t.end();
+});
+
+


### PR DESCRIPTION
Now you can use a "postInitialize"-function which will be triggered just AFTER all "initialize"-functions from parent -states and -collections have been triggerd.
This is necessary when you need to access some (non-binding) properties from a parent-State-object which needs to be altered first in it's own initialize function.