### PR TITLE
send attrs, options to _initChildren

### DIFF
--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -37,7 +37,7 @@ function Base(attrs, options) {
     this.collection = options.collection;
     this._keyTree = new KeyTree();
     this._initCollections();
-    this._initChildren();
+    this._initChildren(attrs, options);
     this._cache = {};
     this._previousAttributes = {};
     if (attrs) this.set(attrs, assign({silent: true, initial: true}, options));


### PR DESCRIPTION
This simply sends the attrs to _initChildren, so that derived models can override _initChildren and reason about the passed in attrs. See #181.