### PR TITLE
Force child states to parse on initial data

### DIFF
--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -454,7 +454,7 @@ assign(Base.prototype, Events, {
         var coll;
         if (!this._collections) return;
         for (coll in this._collections) {
-            this[coll] = new this._collections[coll](null, {parent: this});
+            this[coll] = new this._collections[coll](null, {parent: this, parse: true});
         }
     },
 
@@ -462,7 +462,7 @@ assign(Base.prototype, Events, {
         var child;
         if (!this._children) return;
         for (child in this._children) {
-            this[child] = new this._children[child]({}, {parent: this});
+            this[child] = new this._children[child]({}, {parent: this, parse: true});
             this.listenTo(this[child], 'all', this._getEventBubblingHandler(child));
         }
     },

--- a/test/full.js
+++ b/test/full.js
@@ -1653,3 +1653,63 @@ test('throw helpful error if trying to extend with `prop` that already is define
 
     t.end();
 });
+
+test('#146 consistently apply parse for children and collections', function (t) {
+    var Person = State.extend({
+        props: {
+            name: 'string',
+            parsed: {
+                type: 'number',
+                default: 0
+            }
+        },
+        // parse counts itself as parsed when ran
+        parse: function (attrs) {
+            if (typeof attrs.parsed !== 'number') {
+                attrs.parsed = 0;    
+            }
+            attrs.parsed += 1;
+            return attrs;
+        }
+    });
+
+    var Friends = Collection.extend({
+        model: Person
+    });
+
+    var ParentObj = State.extend({
+        children: {
+            child: Person
+        },
+        collections: {
+            friends: Friends
+        }
+    });
+
+    var Parents = Collection.extend({
+        model: ParentObj
+    });
+
+    var parents = new Parents();
+
+    parents.add([
+        {
+            name: 'first',
+            child: {
+                name: 'mary'
+            },
+            friends: [
+                {
+                    name: 'bob'
+                }
+            ]
+        }
+    ], {parse: true});
+
+    console.log(parents.at(0).friends.length);
+
+    t.equal(parents.at(0).child.parsed, 1, 'child should have been parsed');
+    t.equal(parents.at(0).friends.at(0).parsed, 1, 'friend collection items should have been parsed');
+
+    t.end();
+});


### PR DESCRIPTION
fixes #146

I ran into this issue today, and would like to restart the conversation.

This fixes the failing test @HenrikJoreteg created, but some open questions remain:
- should this be the default behavior for both children and collections?
- if not, does it make sense to add an option somewhere?
