### PR TITLE
add serialize([options]) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,9 +536,9 @@ console.log(me.personID) //=> undefined
 
 **parse** is arguably more useful in ampersand-model, where data typically comes from the server.
 
-### serialize `state.serialize()`
+### serialize `state.serialize([options])`
 
-Serialize the state object into a plain object, ready for sending to the server (typically called via [toJSON](#ampersand-state-tojson)). Of the state's properties, only `props` is returned, `session` and `derived` are omitted. Will also serialize any `children` or `collections` by calling their serialize methods.
+Serialize the state object into a plain object, ready for sending to the server (typically called via [toJSON](#ampersand-state-tojson)). By default, of the state's properties only `props` is returned, while `session` and `derived` are omitted.  You can serialize  `session` or `derived` attributes as well by passing in a options object.  The options object should match that accepted by `.getAttributes(...)`. This method will also serialize any `children` or `collections` by calling their serialize methods.
 
 
 ### get `state.get(attribute); state[attribute]; state.firstName`

--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -104,8 +104,9 @@ assign(Base.prototype, Events, {
 
     // Serialize is the inverse of `parse` it lets you massage data
     // on the way out. Before, sending to server, for example.
-    serialize: function () {
-        var res = this.getAttributes({props: true}, true);
+    serialize: function (options) {
+        var attrOpts = assign({props: true}, options);
+        var res = this.getAttributes(attrOpts, true);
         forEach(this._children, function (value, key) {
             res[key] = this[key].serialize();
         }, this);

--- a/test/full.js
+++ b/test/full.js
@@ -351,6 +351,29 @@ test('serialize should not include session properties no matter how they\'re def
     t.end();
 });
 
+test('serialize should serialize props/derived/session on request', function (t) {
+    var Foo = State.extend({
+        props: {
+            name: 'string'
+        },
+        derived: {
+            derivedAtrr: {
+                fn: function() {
+                    return 'derived-attr';
+                }
+            }
+        },
+        session: {
+            active: 'boolean'
+        }
+    });
+    var foo = new Foo({name: 'hi', active: true});
+    t.deepEqual(foo.serialize({session: true}), {name: 'hi', active: true}, 'serializes session on request');
+    t.deepEqual(foo.serialize({derived: true}), {name: 'hi', derivedAtrr: 'derived-attr'}, 'serializes derived on request');
+    t.deepEqual(foo.serialize({props: false, session: true}), {active: true}, 'serialize ignores props on request');
+    t.end();
+});
+
 test('should fire events normally for properties defined on the fly', function (t) {
     var foo = new Foo();
     foo.extraProperties = 'allow';


### PR DESCRIPTION
# problem statement
I often need my derived attributes serialized.  I end up extending serialize, calling the prototype, then modifying the serialized object in each definition.

# solution
permit serialize to serialize other attr types on demand