### PR TITLE
feature/improve-collision-detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,8 @@ Properties can be defined in three different ways:
 
 * As a string with the expected dataType. One of `string`, `number`, `boolean`, `array`, `object`, `date`, or `any`. (Example: `name: 'string'`.) Can also be set to the name of a custom `dataTypes`, if the class defines any.
 * An array of `[dataType, required, default]`
-* An object `{ type: 'string', required: true, default: '' , values: [], allowNull: false, setOnce: false }`
+* An object `{ type: 'string', required: true, default: '' , values: [], allowNull: false, setOnce: false, squash: true }`
+    * `squash: true` permits you to override previously defined props/derived/session attrs.  Note, only one attr name may be exist across props/derived/session/etc namespaces!
 * `default` will be the value that the property will be set to if it is `undefined` (either by not being set during initialization, or by being explicit set to `undefined`).
 * If `required` is `true`, one of two things will happen
     * If the property has a `default`, it will start with that value, and revert to it after a call to `unset(propertyName)`.

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Properties can be defined in three different ways:
 * As a string with the expected dataType. One of `string`, `number`, `boolean`, `array`, `object`, `date`, or `any`. (Example: `name: 'string'`.) Can also be set to the name of a custom `dataTypes`, if the class defines any.
 * An array of `[dataType, required, default]`
 * An object `{ type: 'string', required: true, default: '' , values: [], allowNull: false, setOnce: false, squash: true }`
-    * `squash: true` permits you to override previously defined props/derived/session attrs.  Note, only one attr name may be exist across props/derived/session/etc namespaces!
+    * `squash` permits you to override previously defined props/derived/session attrs.  Note, only one attr name may be exist across props/derived/session/etc namespaces!  Defaults to `false`.
 * `default` will be the value that the property will be set to if it is `undefined` (either by not being set during initialization, or by being explicit set to `undefined`).
 * If `required` is `true`, one of two things will happen
     * If the property has a `default`, it will start with that value, and revert to it after a call to `unset(propertyName)`.

--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -726,7 +726,7 @@ var stateDefinitions = ['_derived', '_definition', '_collections', '_children'];
 var isStateAttr = function(name, stateCtx) {
     return stateDefinitions.some(bind(function(cat) {
         return stateCtx[cat][name];
-    },this));
+    }, this));
 };
 var removeStateAttr = function(name, stateCtx) {
     return stateDefinitions.forEach(bind(function(cat) {
@@ -735,7 +735,7 @@ var removeStateAttr = function(name, stateCtx) {
 };
 /**
  * Asserts that to-be-defined State-extending attrs (props/session/etc)
- * are not pre-existings.  If `squash` is provided in the definition,
+ * are not pre-existing.  If `squash` is provided in the attr definition,
  * prior defined attrs are wiped from the prototype to avoid collisions
  * @throw {Error} on attr collision
  */

--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -722,6 +722,34 @@ var dataTypes = {
     }
 };
 
+var defCats = ['_derived', '_definition', '_collections', '_children'];
+var isStateAttr = function(name, ctx) {
+    return defCats.some(bind(function(cat) {
+        return ctx[cat][name];
+    },this));
+};
+var removeStateAttr = function(name, ctx) {
+    return defCats.forEach(bind(function(cat) {
+        delete ctx[cat][name];
+    }, this));
+};
+/**
+ * Asserts that to-be-defined State-extending attrs (props/session/etc)
+ * are not pre-existings.  If `squash` is provided in the definition,
+ * prior defined attrs are wiped from the prototype to avoid collisions
+ * @throw {Error} on attr collision
+ */
+var assertNoCollision = function(def, name) {
+    if (isStateAttr(name, this)) {
+        if (def.squash) {
+            return removeStateAttr(name, this);
+        }
+        throw new Error('attempted to define `' + name +
+            '`, although attribute already defined in model. ' +
+            'Did you mean to `squash` it? See &-state docs on `squash`');
+    }
+};
+
 // the extend method used to extend prototypes, maintain inheritance chains for instanceof
 // and allow for additions to the model definitions.
 function extend(protoProps) {
@@ -770,26 +798,31 @@ function extend(protoProps) {
             }
             if (def.props) {
                 forEach(def.props, function (def, name) {
+                    assertNoCollision.apply(child.prototype, [def, name]);
                     createPropertyDefinition(child.prototype, name, def);
                 });
             }
             if (def.session) {
                 forEach(def.session, function (def, name) {
+                    assertNoCollision.apply(child.prototype, [def, name]);
                     createPropertyDefinition(child.prototype, name, def, true);
                 });
             }
             if (def.derived) {
                 forEach(def.derived, function (def, name) {
+                    assertNoCollision.apply(child.prototype, [def, name]);
                     createDerivedProperty(child.prototype, name, def);
                 });
             }
             if (def.collections) {
                 forEach(def.collections, function (constructor, name) {
+                    assertNoCollision.apply(child.prototype, [constructor, name]);
                     child.prototype._collections[name] = constructor;
                 });
             }
             if (def.children) {
                 forEach(def.children, function (constructor, name) {
+                    assertNoCollision.apply(child.prototype, [def, name]);
                     child.prototype._children[name] = constructor;
                 });
             }

--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -722,15 +722,15 @@ var dataTypes = {
     }
 };
 
-var defCats = ['_derived', '_definition', '_collections', '_children'];
-var isStateAttr = function(name, ctx) {
-    return defCats.some(bind(function(cat) {
-        return ctx[cat][name];
+var stateDefinitions = ['_derived', '_definition', '_collections', '_children'];
+var isStateAttr = function(name, stateCtx) {
+    return stateDefinitions.some(bind(function(cat) {
+        return stateCtx[cat][name];
     },this));
 };
-var removeStateAttr = function(name, ctx) {
-    return defCats.forEach(bind(function(cat) {
-        delete ctx[cat][name];
+var removeStateAttr = function(name, stateCtx) {
+    return stateDefinitions.forEach(bind(function(cat) {
+        delete stateCtx[cat][name];
     }, this));
 };
 /**

--- a/test/full.js
+++ b/test/full.js
@@ -1679,29 +1679,16 @@ test('throw helpful error if trying to extend with `prop` that already is define
 
 // https://github.com/AmpersandJS/ampersand-view/issues/96
 test('Provide namespace collision error on collection with property already defined', function (t) {
-    var Parent = State.extend({
-        collections: {
-            items: Collection
-        },
-        items: true
-    });
-
-    var Parent2 = State.extend({
-        props: {
-            items: 'boolean'
-        },
-        collections: {
-            items: Collection
-        }
-    });
-
     t.throws(function () {
+        var Parent = State.extend({
+            collections: {
+                items: Collection
+            },
+            items: true
+        });
         var item = new Parent();
     }, Error, 'Throws collision error on property and collections');
 
-    t.throws(function () {
-        var item = new Parent2();
-    }, Error, 'Throws collision error on collections and props');
     t.end();
 });
 
@@ -1709,25 +1696,72 @@ test('Provide namespace collision error on children with property already define
     var Parent = State.extend({
         children: {
             items: State
-        },
-        items: true
+        }
     });
+    t.throws(function () {
+        var Parent2 = State.extend({
+            props: {
+                items: 'boolean'
+            },
+            children: {
+                items: Collection
+            }
+        });
 
-    var Parent2 = State.extend({
+    }, Error, 'Throws collision error on property and children');
+    t.end();
+});
+
+test('Error on namespace collision for any duplicate attr (prop/session/etc)', function (t) {
+    var Parent = State.extend({
         props: {
-            items: 'boolean'
-        },
-        children: {
-            items: Collection
+            a: 'string'
         }
     });
 
-    t.throws(function () {
-        var item = new Parent();
-    }, Error, 'Throws collision error on property and children');
+    var Gparent;
 
     t.throws(function () {
-        var item = new Parent2();
-    }, Error, 'Throws collision error on children and props');
+        Gparent = Parent.extend({
+            props: {
+                a: 'boolean'
+            }
+        });
+
+    }, Error, 'throws collision error on common named attr (prop)');
+
+    t.throws(function () {
+        Gparent = Parent.extend({
+            derived: {
+                a: {
+                    fn: function() {
+                        throw new Error('should never execute');
+                    }
+                }
+            }
+        });
+
+    }, Error, 'throws collision error on common named attr (derived)');
+
+    t.end();
+});
+
+test('Provide namespace collision squashing for duplicate attr (prop/session/etc)', function (t) {
+    var Parent = State.extend({
+        props: {
+            a: 'string'
+        }
+    });
+    var Gparent = Parent.extend({
+        props: {
+            a: {
+                type: 'number',
+                squash: true,
+                default: 100
+            }
+        }
+    });
+    var gp = new Gparent();
+    t.equal(gp.a, 100, 'duplicate attr squashed');
     t.end();
 });

--- a/test/full.js
+++ b/test/full.js
@@ -1718,11 +1718,10 @@ test('Error on namespace collision for any duplicate attr (prop/session/etc)', f
             a: 'string'
         }
     });
-
-    var Gparent;
+    var Child;
 
     t.throws(function () {
-        Gparent = Parent.extend({
+        Child = Parent.extend({
             props: {
                 a: 'boolean'
             }
@@ -1731,7 +1730,7 @@ test('Error on namespace collision for any duplicate attr (prop/session/etc)', f
     }, Error, 'throws collision error on common named attr (prop)');
 
     t.throws(function () {
-        Gparent = Parent.extend({
+        Child = Parent.extend({
             derived: {
                 a: {
                     fn: function() {
@@ -1752,7 +1751,7 @@ test('Provide namespace collision squashing for duplicate attr (prop/session/etc
             a: 'string'
         }
     });
-    var Gparent = Parent.extend({
+    var Child = Parent.extend({
         props: {
             a: {
                 type: 'number',
@@ -1761,7 +1760,7 @@ test('Provide namespace collision squashing for duplicate attr (prop/session/etc
             }
         }
     });
-    var gp = new Gparent();
-    t.equal(gp.a, 100, 'duplicate attr squashed');
+    var child = new Child();
+    t.equal(child.a, 100, 'duplicate attr squashed');
     t.end();
 });


### PR DESCRIPTION
# problem statement
a ways back, @pgilad rolled collision detection into &-state.  smart.  today, I observed a strange symptom of uncaught collision detection. by having a `Parent` State with a `prop` then a `Child` State with `derived` attr of the same name (silent collision), my derived was caching to a bogus value on initialization.

# solution
improve collision detection

# notes
boy, it took me a while to find.  it's obvious now, but I can't imagine an novice &-js user being able to debug it.  The code doesn't violate our styles, but I'm super open to all opinions on formatting (and general feature implementation of course too).