### PR TITLE
custom datatype onChange function

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ To define a type, you generally will provide an object with 4 member functions (
 
 * `set : function(newVal){};  returns {type : type, val : newVal};`:  Called on every set. Should return an object with two members: `val` and `type`.  If the `type` value does not equal the name of the dataType you defined, a `TypeError` should be thrown.
 * `compare : function(currentVal, newVal, attributeName){}; returns boolean`:  Called on every `set`. Should return `true` if `oldVal` and `newVal` are equal.  Non-equal values will eventually trigger `change` events, unless the state's `set` (not the dataTypes's!) is called with the option `{silent : true}`.
+* `onChange : function (value, previousValue, attributeName){};`: Called after the value changes. Useful for automatically setting up or tearing down listeners on properties.
 * `get : function(val){} returns val;`:  Overrides the default getter of this type.  Useful if you want to make defensive copies.  For example, the `date` dataType returns a clone of the internally saved `date` to keep the internal state consistent.
 * `default : function(){} returns val;`:  Returns the default value for this type.
 

--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -580,15 +580,17 @@ function createPropertyDefinition(object, name, desc, isSession) {
             }
             var value = this._values[name];
             var typeDef = this._dataTypes[def.type];
+            var onSet = this._getOnSetForType(def.type);
             if (typeof value !== 'undefined') {
                 if (typeDef && typeDef.get) {
                     value = typeDef.get(value);
                 }
                 return value;
             }
-            value = result(def, 'default');
-            this._values[name] = value;
-            return value;
+            var defaultValue = result(def, 'default');
+            this._values[name] = defaultValue;
+            onSet(defaultValue, value, name);
+            return defaultValue;
         }
     });
 

--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -118,7 +118,7 @@ assign(Base.prototype, Events, {
         var self = this;
         var extraProperties = this.extraProperties;
         var changing, changes, newType, newVal, def, cast, err, attr,
-            attrs, dataType, silent, unset, currentVal, initial, hasChanged, isEqual, onSet;
+            attrs, dataType, silent, unset, currentVal, initial, hasChanged, isEqual, onChange;
 
         // Handle both `"key", value` and `{key: value}` -style arguments.
         if (isObject(key) || key === null) {
@@ -172,7 +172,7 @@ assign(Base.prototype, Events, {
             }
 
             isEqual = this._getCompareForType(def.type);
-            onSet = this._getOnSetForType(def.type);
+            onChange = this._getOnChangeForType(def.type);
             dataType = this._dataTypes[def.type];
 
             // check type if we have one
@@ -219,7 +219,7 @@ assign(Base.prototype, Events, {
             if (hasChanged) {
                 changes.push({prev: currentVal, val: newVal, key: attr});
                 self._changed[attr] = newVal;
-                onSet(newVal, currentVal, attr);
+                onChange(newVal, currentVal, attr);
             } else {
                 delete self._changed[attr];
             }
@@ -356,9 +356,9 @@ assign(Base.prototype, Events, {
         return _isEqual; // if no compare function is defined, use _.isEqual
     },
 
-    _getOnSetForType : function(type){
+    _getOnChangeForType : function(type){
         var dataType = this._dataTypes[type];
-        if (dataType && dataType.onSet) return bind(dataType.onSet, this);
+        if (dataType && dataType.onChange) return bind(dataType.onChange, this);
         return noop;
     },
 
@@ -580,7 +580,6 @@ function createPropertyDefinition(object, name, desc, isSession) {
             }
             var value = this._values[name];
             var typeDef = this._dataTypes[def.type];
-            var onSet = this._getOnSetForType(def.type);
             if (typeof value !== 'undefined') {
                 if (typeDef && typeDef.get) {
                     value = typeDef.get(value);
@@ -589,7 +588,10 @@ function createPropertyDefinition(object, name, desc, isSession) {
             }
             var defaultValue = result(def, 'default');
             this._values[name] = defaultValue;
-            onSet(defaultValue, value, name);
+            if (typeof defaultValue !== 'undefined') {
+                var onChange = this._getOnChangeForType(def.type);
+                onChange(defaultValue, value, name);
+            }
             return defaultValue;
         }
     });
@@ -714,12 +716,12 @@ var dataTypes = {
             return currentVal === newVal;
         },
 
-        onSet : function(newVal, currentVal, attributeName){
+        onChange : function(newVal, previousVal, attributeName){
             // if this has changed we want to also handle
             // event propagation
 
-            if (currentVal) {
-                this.stopListening(currentVal);
+            if (previousVal) {
+                this.stopListening(previousVal);
             }
 
             if (newVal != null) {

--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -177,7 +177,7 @@ assign(Base.prototype, Events, {
 
             // check type if we have one
             if (dataType && dataType.set) {
-                cast = dataType.set.call(this, newVal, options);
+                cast = dataType.set(newVal);
                 newVal = cast.val;
                 newType = cast.type;
             }

--- a/test/full.js
+++ b/test/full.js
@@ -1849,3 +1849,39 @@ test("#112 - should not set up events on child state if setOnce check fails", fu
 
     t.end();
 });
+
+test('#112 - onSet should be called for default values', function (t) {
+  var Person = State.extend({
+    dataTypes: {
+      'custom-type': {
+        set: function (newVal) {
+          return {
+            type: 'custom-type',
+            val: newVal
+          };
+        },
+        onSet: function (newVal, curVal, name) {
+          t.equal(newVal.value, 100, 'should get the default value as newVal');
+          t.equal(curVal, undefined, 'should get undefined as current value');
+          t.equal(name, 'strength', 'should get the attribute name');
+          t.pass('onSet was called');
+        }
+      }
+    },
+    props: {
+      strength: {
+        type: 'custom-type',
+        default: function () {
+          t.pass('default function should be called');
+          return {
+            value: 100
+          };
+        }
+      }
+    }
+  });
+
+  t.plan(6);
+  var p = new Person();
+  t.equal(p.strength.value, 100);
+});

--- a/test/full.js
+++ b/test/full.js
@@ -1814,3 +1814,38 @@ test('toJSON should serialize customType props - issue #197', function(t) {
 
     t.end();
 });
+
+test("#112 - should not set up events on child state if setOnce check fails", function(t){
+    var Person = State.extend({
+        props : {
+            birthday : {
+                type : 'state',
+                setOnce : true
+            }
+        }
+    });
+    var Birthday = State.extend({
+        props : {
+            day : 'date'
+        }
+    });
+
+    var p = new Person();
+    var bday = new Birthday({day : new Date()});
+    p.once('change:birthday', function() {
+        t.pass('birthday can change once');
+    });
+    p.birthday = bday;
+    var newBday = new Birthday({day : new Date()});
+    t.throws(function() {
+        p.birthday = newBday;
+    }, TypeError, 'Throws error on change of setOnce');
+
+    p.on('change:birthday.day', function() {
+        t.fail('should not trigger change event on old one');
+    });
+
+    newBday.day = new Date(1);
+
+    t.end();
+});

--- a/test/full.js
+++ b/test/full.js
@@ -1850,7 +1850,7 @@ test("#112 - should not set up events on child state if setOnce check fails", fu
     t.end();
 });
 
-test('#112 - onSet should be called for default values', function (t) {
+test('#112 - onChange should be called for default values', function (t) {
   var Person = State.extend({
     dataTypes: {
       'custom-type': {
@@ -1860,11 +1860,11 @@ test('#112 - onSet should be called for default values', function (t) {
             val: newVal
           };
         },
-        onSet: function (newVal, curVal, name) {
+        onChange: function (newVal, curVal, name) {
           t.equal(newVal.value, 100, 'should get the default value as newVal');
           t.equal(curVal, undefined, 'should get undefined as current value');
           t.equal(name, 'strength', 'should get the attribute name');
-          t.pass('onSet was called');
+          t.pass('onChange was called');
         }
       }
     },


### PR DESCRIPTION
Adds an `onChange` function to custom dataType definitions. When defined for a type, `onChange` is called whenever the value of a property with that type changes.

The built-in 'state' type now uses `onChange` to set up and tear down listeners on properties of type 'state', instead of doing so within the `compare` function, which as discussed in #112 has several drawbacks.

This is based on #145 - I rebased @mmacaula's branch on master, added some additional tests and fixes, and renamed `onSet` to `onChange` to avoid confusion with `set`.