### PR TITLE
unset do not throw when using undefined prop. FIX #125

### DIFF
--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -317,6 +317,7 @@ assign(Base.prototype, Events, {
         attrs = Array.isArray(attrs) ? attrs : [attrs];
         attrs.forEach(function (key) {
             var def = self._definition[key];
+            if (!def) return;
             var val;
             if (def.required) {
                 val = result(def, 'default');

--- a/test/basics.js
+++ b/test/basics.js
@@ -528,6 +528,18 @@ test("unset and changedAttributes", function (t) {
     model.unset('a');
 });
 
+test("unset undefined prop", function (t) {
+    var Model = State.extend({
+        props: {
+            a: 'number'
+        }
+    });
+    var model = new Model({a: 1});
+    t.doesNotThrow(function () {
+        model.unset('b');
+    });
+    t.end();
+});
 
 test("change, hasChanged, changedAttributes, previous, previousAttributes", function (t) {
     var Model = State.extend({


### PR DESCRIPTION
Fixes https://github.com/AmpersandJS/ampersand-state/issues/125 :cactus: 

I think that simply exiting early is good enough, as `unset` itself never return any value.