### PR TITLE
Optimization: set

### DIFF
--- a/benchmark/manyProperties.js
+++ b/benchmark/manyProperties.js
@@ -1,0 +1,65 @@
+var State = require('../ampersand-state');
+
+// State slows down massively with many properties.
+// We benchmark this here.
+function createModel() {
+  var aModel = State.extend({
+    derived: {
+      foo: {
+        deps: ['a', 'b'],
+        fn: function derived () {
+          return this.a + this.b;
+        }
+      }
+    }
+  });
+  return aModel;
+}
+
+// Go through most of the normal ascii range.
+// Adjust I and J for larger objects.
+var properties = {};
+for (var i = 0; i < 1; i++) {
+  for (var j = 0; j < 83; j++) {
+    properties[String.fromCharCode(j + 33) + i] = j;
+  }
+}
+
+//Function that contains the pattern to be inspected
+var aModel = createModel();
+function benchFn() {
+  return new aModel(properties).foo;
+}
+
+function printStatus(fn) {
+    switch(%GetOptimizationStatus(fn)) {
+        case 1: console.log("Function is optimized"); break;
+        case 2: console.log("Function is not optimized"); break;
+        case 3: console.log("Function is always optimized"); break;
+        case 4: console.log("Function is never optimized"); break;
+        case 6: console.log("Function is maybe deoptimized"); break;
+    }
+}
+
+//Fill type-info
+benchFn();
+// 2 calls are needed to go from uninitialized -> pre-monomorphic -> monomorphic
+benchFn();
+benchFn();
+benchFn();
+benchFn();
+benchFn();
+
+%OptimizeFunctionOnNextCall(benchFn);
+//The next call
+benchFn();
+
+//Check
+printStatus(benchFn);
+
+
+console.time('manyProperties');
+for (var i = 0; i < 10000;i++) {
+  benchFn();
+}
+console.timeEnd('manyProperties');

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "coverage": "rm -rf coverage && istanbul cover -- tape test/index.js --verbose",
     "validate": "npm ls",
     "lint": "jshint ampersand-state.js ./test/*",
-    "benchmark": "node --allow-natives-syntax benchmark/massCreate.js",
+    "benchmark": "for f in benchmark/*.js; do node --allow-natives-syntax --trace-deopt $f; done",
     "preversion": "git checkout master && git pull && npm ls",
     "publish-patch": "npm run preversion && npm version patch && git push origin master --tags && npm publish",
     "publish-minor": "npm run preversion && npm version minor && git push origin master --tags && npm publish",

--- a/test/full.js
+++ b/test/full.js
@@ -664,9 +664,8 @@ test('Uses dataType compare', function (t) {
 
     compareRun = false;
     var foo = new Foo({ silliness: 'you' });
-    t.assert(compareRun);
+    t.notOk(compareRun);
 
-    compareRun = false;
     foo.silliness = 'they';
     t.assert(compareRun);
     t.end();


### PR DESCRIPTION
Initial creation of a model should be faster due to elimination of _previousAttributes
(which calls expensive getAttributes), looping through change array, and unnecessary
calls to change events and 'compare' hooks on datatypes, when we know the isEqual
check will fail.

I'll make some line notes just to clarify why I made certain changes.