### PR TITLE
Making it possible to State.set('anyChild', null) again

### DIFF
--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -162,6 +162,10 @@ assign(Base.prototype, Events, {
             if (!def) {
                 // if this is a child model or collection
                 if (this._children[attr] || this._collections[attr]) {
+                    if (!isObject(newVal)) {
+                        newVal = {};
+                    }
+
                     this[attr].set(newVal, options);
                     continue;
                 } else if (extraProperties === 'ignore') {

--- a/test/full.js
+++ b/test/full.js
@@ -971,6 +971,11 @@ test('children and collections should be instantiated', function (t) {
     t.equal(first.firstChild.id, 'firstChild', 'change should have been applied');
     t.equal(first.firstChild.grandChild.nicknames.length, 3, 'collection should have been updated');
 
+    // it should be ok to pass `null` as the child
+    first.set("firstChild", null);
+    first.set({"firstChild": undefined});
+    t.equal(first.firstChild.id, "firstChild");
+
     t.end();
 });
 


### PR DESCRIPTION
With the `4.9.0`, the change in [this line](https://github.com/AmpersandJS/ampersand-state/commit/4518954522ab4beca10b5d7fd0bfc2ee69e3a5b0#diff-8a9bf6b5d6e0c56925dadb3c3f2ae1b5R155) broke the behaviour of being possible to pass `null` or `undefined` to as a child.

I dunno if this is the desired behaviour, however, it was already possible before, so it would be nice keeping it as is :smile_cat: 