### PR TITLE
Fix typo in collections example

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ var WidgetCollection = Collection.extend({
     model: Widget
 });
 
-var Person = AmpersandState.extend({
+var Person = State.extend({
     props: {
         name: 'string'
     },


### PR DESCRIPTION
The `ampersand-state` dependency is named `State` in this code sample