### PR TITLE
Fix stopListening when changing a prop of type "state"

### DIFF
--- a/test/full.js
+++ b/test/full.js
@@ -1890,3 +1890,26 @@ test('#112 - onChange should be called for default values', function (t) {
   var p = new Person();
   t.equal(p.strength.value, 100);
 });
+
+test('keeps event listeners when changing property of type state', function (t) {
+  var Organization = State.extend({});
+  var Person = State.extend({
+    props: {
+      organization: { type: 'state' }
+    },
+    initialize: function() {
+      this.listenTo(this.organization, 'customEvent', function() {
+        t.pass('customEvent handler was called');
+      });
+    },
+  });
+
+  t.plan(1);
+  var orgA = new Organization();
+  var orgB = new Organization();
+  var p = new Person({ organization: orgA });
+  p.organization = orgB;
+  orgA.trigger('customEvent');
+  t.end();
+});
+


### PR DESCRIPTION
Ampersand used to just call `this.stopListening` on a property of type
"state" whenever we changed it out for some other object. However,
this also unbinds any other listeners on that object, unexpectedly.

Instead, we should keep a reference to the handler, which we do by
changing `_getEventBubblingHandler` into
`_getCachedEventBubblingHandler` and saving it for the `propertyName`.
This way, we can unbind just the handler we just set, and leave other
event listeners untouched.