### PR TITLE
Fixes fetching null collections with one dummy element from server

### DIFF
--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -163,7 +163,7 @@ assign(Base.prototype, Events, {
             if (!def) {
                 // if this is a child model or collection
                 if (this._children[attr] || this._collections[attr]) {
-                    if (!isObject(newVal)) {
+                    if (!isObject(newVal) && this._children[attr]) {
                         newVal = {};
                     }
 

--- a/test/full.js
+++ b/test/full.js
@@ -1913,3 +1913,29 @@ test('keeps event listeners when changing property of type state', function (t) 
   t.end();
 });
 
+test('passing null to set method should not create a new collection with one dummy element', function (t) {
+  var Friends = Collection.extend({
+    model: Person
+  });
+  
+  var Person = State.extend({
+    props: {
+      name: 'string'
+    },
+    collections: {
+      friends: Friends
+    }
+  });
+
+  t.plan(1);  
+  var p = new Person({ name : 'Joe' });
+  
+  p.set("friends", null);
+  p.set({"friends": undefined});
+  
+  console.log(p.friends.models.length);
+  
+  t.equal(p.friends.models.length, 0);
+
+  t.end();
+});


### PR DESCRIPTION
Do not create a dummy member in a collection when null is passed to set method
