### PR TITLE
Pass change event options from children to parent

### DIFF
--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -506,11 +506,13 @@ assign(Base.prototype, Events, {
     // adding a name to the change string.
     _getCachedEventBubblingHandler: function (propertyName) {
         if (!this._eventBubblingHandlerCache[propertyName]) {
-            this._eventBubblingHandlerCache[propertyName] = bind(function (name, model, newValue) {
+            this._eventBubblingHandlerCache[propertyName] = bind(function (name, model, newValue, options) {
                 if (changeRE.test(name)) {
-                    this.trigger('change:' + propertyName + '.' + name.split(':')[1], model, newValue);
+                    var parentName = 'change:' + propertyName + '.' + name.split(':')[1];
+                    this.trigger(parentName, model, newValue, options);
                 } else if (name === 'change') {
-                    this.trigger('change', this);
+                    options = newValue;
+                    this.trigger('change', this, options);
                 }
             }, this);
         }

--- a/test/full.js
+++ b/test/full.js
@@ -1053,7 +1053,7 @@ test('listens to child events', function (t) {
         }
     });
 
-    t.plan(7);
+    t.plan(9);
 
     //Change property
     first.once('change:name', function (model, newVal) {
@@ -1070,17 +1070,19 @@ test('listens to child events', function (t) {
     t.equal(first.firstChild.name, 'new-first-child-name');
 
     //Change grand child property
-    first.once('change:firstChild.grandChild.name', function (unsure, name) {
+    first.once('change:firstChild.grandChild.name', function (unsure, name, options) {
         t.equal(name, 'Phil');
+        t.ok(options.passesOptions, 'Options are passed');
     });
-    first.firstChild.grandChild.name = 'Phil';
+    first.firstChild.grandChild.set({name: 'Phil'}, {passesOptions: true});
     t.equal(first.firstChild.grandChild.name, 'Phil');
 
     //Propagates change events from children too
-    first.once('change', function (model) {
+    first.once('change', function (model, options) {
         t.equal(model, first);
+        t.ok(options.passesOptions, 'Options are passed');
     });
-    first.firstChild.grandChild.name = 'Bob';
+    first.firstChild.grandChild.set({name: 'Bob'}, {passesOptions: true});
 });
 
 test('Should be able to declare derived properties that have nested deps', function (t) {


### PR DESCRIPTION
I use event options to pass metadata when setting properties, this change fixes a bug when children change event options are not passed to parent event listeners