### PR TITLE
Collections model props as deps in derived.

### DIFF
--- a/ampersand-state.js
+++ b/ampersand-state.js
@@ -460,6 +460,19 @@ assign(Base.prototype, Events, {
 
             def.deps.forEach(function (propString) {
                 self._keyTree.add(propString, update);
+                if (propString.indexOf('.') > -1) {
+                    var collection = propString.split('.')[0];
+                    if (self[collection] && self[collection].isCollection) {
+                        if (!self._collectionEvents[propString]) {
+                            self._collectionEvents[propString] = true;
+                            self[collection].on('change:' + propString.split('.')[1], function () {
+                                self._keyTree.get(propString).forEach(function (fn) {
+                                    fn();
+                                });
+                            });
+                        }
+                    }
+                }
             });
         });
 


### PR DESCRIPTION
Allows specifying collection's model property as the dependency in derived property.  So if given property will change in any of the collection's models, derived will be re-calculated. Introduces private property _collectionEvents, to store already subscribed events, and to do not subscribe twice for the same event in case if multiple derived properties will use the same dependency.